### PR TITLE
Feature/tavern meta dict

### DIFF
--- a/tavern/core.py
+++ b/tavern/core.py
@@ -3,8 +3,8 @@ import os
 
 import yaml
 
-from box import Box
 from contextlib2 import ExitStack
+from box import Box
 
 from .util import exceptions
 from .util.delay import delay

--- a/tavern/core.py
+++ b/tavern/core.py
@@ -87,8 +87,6 @@ def run_test(in_file, test_spec, global_cfg):
 
             tavern_box.update(request_vars=r.request_vars)
 
-            logger.critical(test_block_config)
-
             try:
                 expected = get_expected(stage, test_block_config, sessions)
             except exceptions.TavernException:

--- a/tavern/core.py
+++ b/tavern/core.py
@@ -1,7 +1,9 @@
 import logging
+import os
 
 import yaml
 
+from box import Box
 from contextlib2 import ExitStack
 
 from .util import exceptions
@@ -45,6 +47,10 @@ def run_test(in_file, test_spec, global_cfg):
 
     if "variables" not in test_block_config:
         test_block_config["variables"] = {}
+
+    test_block_config["variables"]["tavern"] = Box({
+        "env_vars": dict(os.environ),
+    })
 
     if not test_spec:
         logger.warning("Empty test block in %s", in_file)

--- a/tavern/request/base.py
+++ b/tavern/request/base.py
@@ -1,8 +1,14 @@
 from abc import abstractmethod
 
+from box import Box
+
 
 class BaseRequest(object):
 
     @abstractmethod
     def run(self):
         """Run test"""
+
+    @property
+    def request_vars(self):
+        return Box(self._request_args)

--- a/tavern/request/base.py
+++ b/tavern/request/base.py
@@ -1,14 +1,8 @@
 from abc import abstractmethod
 
-from box import Box
-
 
 class BaseRequest(object):
 
     @abstractmethod
     def run(self):
         """Run test"""
-
-    @property
-    def request_vars(self):
-        return Box(self._request_args)

--- a/tavern/request/mqtt.py
+++ b/tavern/request/mqtt.py
@@ -51,9 +51,12 @@ class MQTTRequest(BaseRequest):
 
         publish_args = get_publish_args(rspec, test_block_config)
 
-        self._publish_args = publish_args
-
         self._prepared = functools.partial(client.publish, **publish_args)
+
+        # Need to do this here because get_publish_args will modify the original
+        # input, which we might want to use to format. No error handling because
+        # all the error handling is done in the previous call
+        self._original_publish_args = format_keys(rspec, test_block_config)
 
         # TODO
         # From paho:
@@ -70,4 +73,4 @@ class MQTTRequest(BaseRequest):
 
     @property
     def request_vars(self):
-        return Box(self._publish_args)
+        return Box(self._original_publish_args)

--- a/tavern/request/mqtt.py
+++ b/tavern/request/mqtt.py
@@ -3,6 +3,7 @@ import json
 import functools
 
 from future.utils import raise_from
+from box import Box
 
 from tavern.util import exceptions
 from tavern.util.dict_util import format_keys, check_expected_keys
@@ -50,7 +51,7 @@ class MQTTRequest(BaseRequest):
 
         publish_args = get_publish_args(rspec, test_block_config)
 
-        self._request_args = publish_args
+        self._publish_args = publish_args
 
         self._prepared = functools.partial(client.publish, **publish_args)
 
@@ -66,3 +67,7 @@ class MQTTRequest(BaseRequest):
         except ValueError as e:
             logger.exception("Error publishing")
             raise_from(exceptions.MQTTRequestException, e)
+
+    @property
+    def request_vars(self):
+        return Box(self._publish_args)

--- a/tavern/request/mqtt.py
+++ b/tavern/request/mqtt.py
@@ -50,6 +50,8 @@ class MQTTRequest(BaseRequest):
 
         publish_args = get_publish_args(rspec, test_block_config)
 
+        self._request_args = publish_args
+
         self._prepared = functools.partial(client.publish, **publish_args)
 
         # TODO

--- a/tavern/request/rest.py
+++ b/tavern/request/rest.py
@@ -150,17 +150,17 @@ class RestRequest(BaseRequest):
 
         check_expected_keys(expected, rspec)
 
-        request_args = get_request_args(rspec, test_block_config)
+        self._request_args = get_request_args(rspec, test_block_config)
 
-        logger.debug("Request args: %s", request_args)
+        logger.debug("Request args: %s", self._request_args)
 
-        request_args.update(allow_redirects=False)
+        self._request_args.update(allow_redirects=False)
 
         # There is no way using requests to make a prepared request that will
         # not follow redicrects, so instead we have to do this. This also means
         # that we can't have the 'pre-request' hook any more because we don't
         # create a prepared request.
-        self._prepared = functools.partial(session.request, **request_args)
+        self._prepared = functools.partial(session.request, **self._request_args)
 
     def run(self):
         """ Runs the prepared request and times it

--- a/tavern/response/base.py
+++ b/tavern/response/base.py
@@ -59,7 +59,7 @@ class BaseResponse(object):
                 self._adderr("expected %s in the %s, but there was no response body",
                     expected_block, blockname)
             else:
-                logger.debug("block = %s", expected_block)
+                logger.debug("expected = %s, actual = %s", expected_block, block)
                 for split_key, joined_key, expected_val in yield_keyvals(expected_block):
                     try:
                         actual_val = recurse_access_key(block, split_key)

--- a/tavern/response/mqtt.py
+++ b/tavern/response/mqtt.py
@@ -59,7 +59,7 @@ class MQTTResponse(BaseResponse):
         # TODO move this check to initialisation/schema checking
         if "json" in self.expected:
             if "payload" in self.expected:
-                raise exceptions.BadSchemaError("Can only specify one of 'payload' or 'json' in MQTT request")
+                raise exceptions.BadSchemaError("Can only specify one of 'payload' or 'json' in MQTT response")
 
             payload = self.expected["json"]
             json_payload = True


### PR DESCRIPTION
Adds a 'tavern' value for formatting values. Currently it contains:

- `tavern.env_vars` - variables from the environment, got when the test is first run
- `tavern.request_vars` - variables from the `request`/`mqtt_publish` for the current stage. This can be used if, for example, you expected a value to be echoed back from the server:

```yaml
request:
    json:
        thing: value
response:
    body:
        echoed: "{tavern.request_vars.json.thing}"
```

- closes #22 
- closes #4 
- closes #34