### PR TITLE
Add variables support for arrays

### DIFF
--- a/tavern/util/dict_util.py
+++ b/tavern/util/dict_util.py
@@ -32,6 +32,8 @@ def format_keys(val, variables):
         except KeyError as e:
             logger.error("Key(s) not found in format: %s", e.args)
             raise_from(exceptions.MissingFormatError(e.args), e)
+    elif isinstance(val, (list, tuple)):
+        formatted = [format_keys(item, variables) for item in val]
 
     return formatted
 

--- a/tests/response/test_rest.py
+++ b/tests/response/test_rest.py
@@ -22,6 +22,50 @@ def fix_example_response():
     return spec.copy()
 
 
+@pytest.fixture(name='nested_response')
+def fix_nested_response():
+    # https://github.com/taverntesting/tavern/issues/45
+    spec = {
+        "status_code": 200,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "users": [
+                {
+                    "u": {
+                        "user_id": "def456"
+                    }
+                }
+            ]
+        }
+    }
+
+    return spec.copy()
+
+
+@pytest.fixture(name='nested_schema')
+def fix_nested_schema():
+    # https://github.com/taverntesting/tavern/issues/45
+    spec = {
+        "status_code": 200,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "users": [
+                {
+                    "u": {
+                        "user_id": "{code}"
+                    }
+                }
+            ]
+        }
+    }
+
+    return spec.copy()
+
+
 class TestSave:
 
     def test_save_body(self, resp, includes):
@@ -217,3 +261,16 @@ class TestFull:
             r.verify(FakeResponse())
 
         assert r.errors
+
+    def test_saved_value_in_validate(self, nested_response, nested_schema,
+                                     includes):
+        r = RestResponse(Mock(), "Test 1", nested_schema, includes)
+
+        class FakeResponse:
+            headers = nested_response["headers"]
+            content = "test".encode("utf8")
+            def json(self):
+                return nested_response["body"]
+            status_code = nested_response["status_code"]
+
+        r.verify(FakeResponse())

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -25,6 +25,10 @@ def fix_example_request():
             "a_thing":  "authorization_code",
             "code":  "{code:s}",
             "url":  "{callback_url:s}",
+            "array": [
+                "{code:s}",
+                "{code:s}",
+            ]
         },
     }
 
@@ -128,6 +132,11 @@ class TestRequests:
         args = get_request_args(req, includes)
 
         assert args["params"]["a"] == "%7B%22b%22%3A+%7B%22c%22%3A+%22d%22%7D%7D"
+
+    def test_array_substitution(self, req, includes):
+        args = get_request_args(req, includes)
+
+        assert args['data']['array'] == ['def456', 'def456']
 
 
 class TestExtFunctions:


### PR DESCRIPTION
This small PR adds the support for formatted strings/variables in arrays, see also #42.

```yaml
json:
  foo:
    - "{bar:s}"
```
