### PR TITLE
Add basic pytest fixture support [WIP]

### DIFF
--- a/example/pytest/conftest.py
+++ b/example/pytest/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def number():
+    return 123
+
+
+@pytest.fixture
+def double(number):
+    return number * 2

--- a/example/pytest/server.py
+++ b/example/pytest/server.py
@@ -1,0 +1,21 @@
+from flask import Flask, jsonify, request
+
+
+app = Flask(__name__)
+
+
+@app.route("/double", methods=["POST"])
+def double_number():
+    r = request.get_json()
+
+    try:
+        number = r["number"]
+    except (KeyError, TypeError):
+        return jsonify({"error": "no number passed"}), 400
+
+    try:
+        double = int(number)*2
+    except ValueError:
+        return jsonify({"error": "a number was not passed"}), 400
+
+    return jsonify({"double": double}), 200

--- a/example/pytest/test_server.tavern.yaml
+++ b/example/pytest/test_server.tavern.yaml
@@ -1,0 +1,22 @@
+---
+
+test_name: Make sure server doubles number properly
+pytest:
+  fixtures:
+    input: number
+    expected: double
+
+
+stages:
+  - name: Make sure number is returned correctly
+    request:
+      url: http://localhost:5000/double
+      json:
+        number: "{input:d}"
+      method: POST
+      headers:
+        content-type: application/json
+    response:
+      status_code: 200
+      body:
+        double: "{expected:d}"

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -11,6 +11,17 @@ mapping:
     required: true
     type: str
 
+  pytest:
+    required: false
+    type: map
+    mapping:
+      fixtures:
+        type: map
+        required: false
+        mapping:
+          re;(.*):
+            type: any
+
   mqtt:
     required: false
     type: map


### PR DESCRIPTION
# Work in progress

referencing #8 

This PR adds basic support for pytest fixtures. Fixtures specified in the test as well as autoloaded fixtures are evaluated and their results are available in the test.

basic example, adapted from the `simple` example from the repo:

```yaml
test_name: Make sure server doubles number properly
pytest:
  fixtures:
    # store result of fixture "number" in variable "input"
    input: number
    # store result of fixture "double" in variable "expected"
    expected: double

stages:
  - name: Make sure number is returned correctly
    request:
      url: http://localhost:5000/double
      json:
        number: "{input:d}"
      method: POST
      headers:
        content-type: application/json
    response:
      status_code: 200
      body:
        # type information is lost here, so this fails.
        double: "{expected:d}"
```


**What works so far** 

* reference fixtures in the same way as variables
* use fixtures marked as `autouse`

**What does not work**

* parametrized fixtures
* using non-string fixture values in responses (example in repository fails because of this, see #20)

**This needs to be tested thoroughly, I am no pytest expert and do not know if this works in all cases or breaks in other than basic ones.**

Any thoughts/feedback on this would be appreciated.