### PR TITLE
Adds file upload functionality

### DIFF
--- a/tavern/request/rest.py
+++ b/tavern/request/rest.py
@@ -1,4 +1,3 @@
-import functools
 import json
 import logging
 import warnings
@@ -8,6 +7,7 @@ try:
 except ImportError:
     from urllib import quote_plus
 
+from contextlib2 import ExitStack
 from future.utils import raise_from
 import requests
 from box import Box
@@ -113,7 +113,6 @@ def get_request_args(rspec, test_block_config):
     for key, val in optional_with_default.items():
         request_args[key] = fspec.get(key, val)
 
-    # Open file handlers for all files
     for key, value in request_args.get("files", {}).items():
         request_args["files"][key] = open(value, "rb")
 
@@ -176,10 +175,22 @@ class RestRequest(BaseRequest):
         self._request_args = request_args
 
         # There is no way using requests to make a prepared request that will
-        # not follow redicrects, so instead we have to do this. This also means
+        # not follow redirects, so instead we have to do this. This also means
         # that we can't have the 'pre-request' hook any more because we don't
         # create a prepared request.
-        self._prepared = functools.partial(session.request, **request_args)
+        def prepared_request():
+
+            # If there are open files, create a context manager around each so they
+            # will be closed at the end of the request.
+            if "files" in self._request_args:
+                with ExitStack() as stack:
+                    for open_file_handle in self._request_args["files"].values():
+                        stack.enter_context(open_file_handle)
+                    return session.request(**self._request_args)
+            else:
+                return session.request(**self._request_args)
+
+        self._prepared = prepared_request
 
     def run(self):
         """ Runs the prepared request and times it

--- a/tavern/request/rest.py
+++ b/tavern/request/rest.py
@@ -179,13 +179,10 @@ class RestRequest(BaseRequest):
         def prepared_request():
             # If there are open files, create a context manager around each so
             # they will be closed at the end of the request.
-            if "files" in self._request_args:
-                with ExitStack() as stack:
-                    for key, filepath in self._request_args["files"].items():
-                        self._request_args["files"][key] = stack.enter_context(
-                                open(filepath, "rb"))
-                    return session.request(**self._request_args)
-            else:
+            with ExitStack() as stack:
+                for key, filepath in self._request_args.get("files", {}).items():
+                    self._request_args["files"][key] = stack.enter_context(
+                            open(filepath, "rb"))
                 return session.request(**self._request_args)
 
         self._prepared = prepared_request

--- a/tavern/request/rest.py
+++ b/tavern/request/rest.py
@@ -52,6 +52,7 @@ def get_request_args(rspec, test_block_config):
         "data",
         "params",
         "headers",
+        "files"
         # Ideally this would just be passed through but requests seems to error
         # if we pass a list instead of a tuple, so we have to manually convert
         # it further down
@@ -112,9 +113,12 @@ def get_request_args(rspec, test_block_config):
     for key, val in optional_with_default.items():
         request_args[key] = fspec.get(key, val)
 
+    # Open file handlers for all files
+    for key, value in request_args.get("files", {}).items():
+        request_args["files"][key] = open(value, "rb")
+
     # TODO
     # requests takes all of these - we need to parse the input to get them
-    # "files",
     # "cookies",
 
     # These verbs _can_ send a body but the body _should_ be ignored according
@@ -156,7 +160,7 @@ class RestRequest(BaseRequest):
             "auth",
             "json",
             "verify",
-            # "files",
+            "files",
             # "cookies",
             # "hooks",
         }

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -182,6 +182,13 @@ mapping:
                 type: any
                 required: false
 
+              files: 
+                required: false
+                type: map 
+                mapping:
+                  re;(.*):
+                    type: str
+
               method:
                 type: str
                 enum:

--- a/tests/integration/server.py
+++ b/tests/integration/server.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify
+import os
 
 
 app = Flask(__name__)
@@ -62,6 +63,21 @@ def nested_list_response():
         ]
     }
     return jsonify(response), 200
+
+
+@app.route("/fake_upload_file", methods=["POST"])
+def upload_fake_file():
+    if not request.files:
+        return '', 401
+
+    # Try to download each of the files downloaded to /tmp and
+    # then remove them
+    for key in request.files:
+        file_to_save = request.files[key]
+        path = os.path.join("/tmp", file_to_save.filename)
+        file_to_save.save(path)
+
+    return '', 200
 
 
 @app.route("/nested/again", methods=["GET"])

--- a/tests/integration/test_files.tavern.yaml
+++ b/tests/integration/test_files.tavern.yaml
@@ -1,0 +1,17 @@
+---
+
+test_name: Test files can be uploaded with tavern
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: Upload multiple files
+    request:
+      url: "{host}/fake_upload_file"
+      method: POST
+      files:
+        test_files: "test_files.tavern.yaml"
+        common: "common.yaml"
+    response:
+      status_code: 200


### PR DESCRIPTION
Addresses #25 

The gist of this implementation is that files are opened when the arguments to `requests` are parsed.  A context manager is added to each open file before the request gets submitted so the files will be closed after the request completes.  All context managers are bundled in an `ExitStack` coming from the `contextlib2` module so it should be python 2.7 compatible.

https://contextlib2.readthedocs.io/en/stable/#contextlib2.ExitStack

An example of how this looks added to the YAML for a request

    stages:
      name: Upload multiple files
      request:
      url: "{host}/fake_upload_file"
      method: POST
      files:
        test_files: "test_files.tavern.yaml"
        common: "common.yaml"
      response:
        status_code: 200

I added in an integration test that accepts file uploads and 200s, otherwise if no files were specified it 401s.  If there's a better way to automatically test this functionality let me know and I'd be happy to pursue it.