### PR TITLE
Add skip/only keywords for selective/isolated stages

### DIFF
--- a/tavern/core.py
+++ b/tavern/core.py
@@ -78,47 +78,55 @@ def run_test(in_file, test_spec, global_cfg):
 
         # Run tests in a path in order
         for stage in test_spec["stages"]:
-            name = stage["name"]
+            if stage.get('skip'):
+                continue
 
-            try:
-                r = get_request_type(stage, test_block_config, sessions)
-            except exceptions.MissingFormatError:
-                log_fail(stage, None, None)
-                raise
+            run_stage(sessions, stage, tavern_box, test_block_config)
 
-            tavern_box.update(request_vars=r.request_vars)
+            if stage.get('only'):
+                break
 
-            try:
-                expected = get_expected(stage, test_block_config, sessions)
-            except exceptions.TavernException:
-                log_fail(stage, None, None)
-                raise
 
-            delay(stage, "before")
+def run_stage(sessions, stage, tavern_box, test_block_config):
+    name = stage["name"]
 
-            logger.info("Running stage : %s", name)
+    try:
+        r = get_request_type(stage, test_block_config, sessions)
+    except exceptions.MissingFormatError:
+        log_fail(stage, None, None)
+        raise
 
-            try:
-                response = r.run()
-            except exceptions.TavernException:
-                log_fail(stage, None, expected)
-                raise
+    tavern_box.update(request_vars=r.request_vars)
 
-            verifiers = get_verifiers(stage, test_block_config, sessions, expected)
+    try:
+        expected = get_expected(stage, test_block_config, sessions)
+    except exceptions.TavernException:
+        log_fail(stage, None, None)
+        raise
 
-            for v in verifiers:
-                try:
-                    saved = v.verify(response)
-                except exceptions.TavernException:
-                    log_fail(stage, v, expected)
-                    raise
-                else:
-                    test_block_config["variables"].update(saved)
+    delay(stage, "before")
 
-            log_pass(stage, verifiers)
+    logger.info("Running stage : %s", name)
+    try:
+        response = r.run()
+    except exceptions.TavernException:
+        log_fail(stage, None, expected)
+        raise
 
-            tavern_box.pop("request_vars")
-            delay(stage, "after")
+    verifiers = get_verifiers(stage, test_block_config, sessions, expected)
+    for v in verifiers:
+        try:
+            saved = v.verify(response)
+        except exceptions.TavernException:
+            log_fail(stage, v, expected)
+            raise
+        else:
+            test_block_config["variables"].update(saved)
+
+    log_pass(stage, verifiers)
+
+    tavern_box.pop("request_vars")
+    delay(stage, "after")
 
 
 def run(in_file, tavern_global_cfg):

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -135,6 +135,14 @@ mapping:
             required: true
             unique: true
 
+          skip:
+            type: bool
+            required: false
+
+          only:
+            type: bool
+            required: false
+
           delay_before:
             type: float
             required: false

--- a/tests/integration/test_selective_tests.tavern.yaml
+++ b/tests/integration/test_selective_tests.tavern.yaml
@@ -1,0 +1,28 @@
+---
+
+test_name: Test 'only' keyword for test isolation
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: This is the only test that should run
+    only: yes
+    request:
+      url: "{host}/fake_list"
+      method: GET
+    response:
+      status_code: 200
+  - name: This should be ignored
+    request:
+      url: "{host}/fake_list"
+      method: GET
+    response:
+      status_code: 999
+  - name: This should also be ignored because it's not the first 'only' test
+    only: yes
+    request:
+      url: "{host}/fake_list"
+      method: GET
+    response:
+      status_code: 999

--- a/tests/integration/test_skipped_tests.tavern.yaml
+++ b/tests/integration/test_skipped_tests.tavern.yaml
@@ -1,0 +1,21 @@
+---
+
+test_name: Test 'skip' keyword for selectively ignoring tests
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: This test should not run
+    skip: yes
+    request:
+      url: "{host}/fake_list"
+      method: GET
+    response:
+      status_code: 999
+  - name: This test should still run
+    request:
+      url: "{host}/fake_list"
+      method: GET
+    response:
+      status_code: 200


### PR DESCRIPTION
Adding this for the following use case:

* During development, one might want to only run a single stage in a test without running everything else (which can be time consuming)
* During development, one might want to skip a test that is flaky, or broken due to a known issue, whilst retaining the stage code so that it can be conveniently un-skipped later

The changes were relatively simple, except for one thing - I had to split the run_test function into two to satisfy pylint (it was reporting too-many-statements for the run_test function 52/50). I hope that's okay.
