### PR TITLE
Allow test variables to be nested

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,19 +141,21 @@ to run the integration tests, make sure you have
 ``tox -c tox-integraton.ini`` (bear in mind this might take a while.)
 It's that simple!
 
-If you want to add a feature to get merged back into mainline Tavern: -
-Add the feature you want - Add some tests for your feature: - If you are
-adding some utility functionality such as improving verification of
-responses, adding some unit tests might be best. These are in the
-``tests/unit/`` folder and are written using Pytest. - If you are adding
-more advanced functionality like extra validation functions, or some
-functionality that directly depends on the format of the input YAML, it
-might also be useful to add some integration tests. At the time of
-writing, this is done by adding an example flask endpoint in
-``tests/integration/server.py`` and a corresponding Tavern YAML test
-file in the same directory. This will be cleaned up a bit once we have a
-proper plugin system implemented. - Open a `pull
-request <https://github.com/taverntesting/tavern/pulls>`__.
+If you want to add a feature to get merged back into mainline Tavern:
+
+-  Add the feature you want
+-  Add some tests for your feature:
+-  If you are adding some utility functionality such as improving verification
+   of responses, adding some unit tests might be best. These are in the
+   ``tests/unit/`` folder and are written using Pytest.
+-  If you are adding more advanced functionality like extra validation
+   functions, or some functionality that directly depends on the format of the
+   input YAML, it might also be useful to add some integration tests. At the
+   time of writing, this is done by adding an example flask endpoint in
+   ``tests/integration/server.py`` and a corresponding Tavern YAML test file in
+   the same directory. This will be cleaned up a bit once we have a proper
+   plugin system implemented.
+-  Open a `pull request <https://github.com/taverntesting/tavern/pulls>`__.
 
 Note that Tavern supports Python 2.7 (for the time being), so any code
 you add has to be compatible with it. We currently use the

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,10 @@ import pytest
 def fix_example_includes():
     includes = {
         "variables": {
-            "request_url": "www.google.com",
+            "request": {
+                "prefix": "www.",
+                "url": "google.com",
+            },
             "test_auth_token": "abc123",
             "code": "def456",
             "callback_url": "www.yahoo.co.uk",

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -15,7 +15,7 @@ from tavern.util import exceptions
 @pytest.fixture(name="req")
 def fix_example_request():
     spec = {
-        "url":  "{request_url:s}",
+        "url":  "{request.prefix:s}{request.url:s}",
         "method":  "POST",
         "headers": {
             "Content-Type": "application/x-www-form-urlencoded",


### PR DESCRIPTION
Update the format_keys() function to change the variables dict to a Box
object. This allows the the test variables to be nested. For example:

  variables:
    users:
      foo:
        username: foo
        password: foo_pass
      bar:
        username: bar
        password: bar_pass

Then in the test spec they can be referenced as "{users.foo.username:s}"
and "{users.bar.username}".

Updated the unit tests "includes" fixture to have nested variables for
the request, and the "req" fixure for the requests test to reference the
nested variables.