### PR TITLE
Add custom before and after handlers for test stages

### DIFF
--- a/example/timing/Dockerfile
+++ b/example/timing/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.5-alpine
+
+RUN pip install flask pyjwt
+
+COPY server.py /
+
+ENV FLASK_APP=/server.py
+
+CMD ["flask", "run", "--host=0.0.0.0"]

--- a/example/timing/common.yaml
+++ b/example/timing/common.yaml
@@ -1,0 +1,6 @@
+---
+name: test includes
+description: used for testing against local server
+
+variables:
+  host: http://localhost:5001

--- a/example/timing/docker-compose.yaml
+++ b/example/timing/docker-compose.yaml
@@ -1,0 +1,10 @@
+---
+version: '2'
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "5001:5000"

--- a/example/timing/readme.md
+++ b/example/timing/readme.md
@@ -1,0 +1,6 @@
+# Timing example
+
+This example uses custom before and after handlers to measure request
+times.
+
+Run pytest with `-s` or `--capture=no` to see logging output.

--- a/example/timing/server.py
+++ b/example/timing/server.py
@@ -1,0 +1,21 @@
+from flask import Flask, jsonify, request
+
+
+app = Flask(__name__)
+
+
+@app.route("/double", methods=["POST"])
+def double_number():
+    r = request.get_json()
+
+    try:
+        number = r["number"]
+    except (KeyError, TypeError):
+        return jsonify({"error": "no number passed"}), 400
+
+    try:
+        double = int(number)*2
+    except ValueError:
+        return jsonify({"error": "a number was not passed"}), 400
+
+    return jsonify({"double": double}), 200

--- a/example/timing/test_server.tavern.yaml
+++ b/example/timing/test_server.tavern.yaml
@@ -1,0 +1,21 @@
+---
+
+test_name: Make sure server doubles number properly
+
+stages:
+  - name: Make sure number is returned correctly
+    before:
+      - function: utils:timer_start
+    after:
+      - function: utils:timer_stop
+    request:
+      url: http://localhost:5001/double
+      json:
+        number: 5
+      method: POST
+      headers:
+        content-type: application/json
+    response:
+      status_code: 200
+      body:
+        double: 10

--- a/example/timing/test_server.tavern.yaml
+++ b/example/timing/test_server.tavern.yaml
@@ -5,17 +5,18 @@ test_name: Make sure server doubles number properly
 stages:
   - name: Make sure number is returned correctly
     before:
+      - function: utils:load_number
       - function: utils:timer_start
     after:
       - function: utils:timer_stop
     request:
       url: http://localhost:5001/double
       json:
-        number: 5
+        number: !int "{input:d}"
       method: POST
       headers:
         content-type: application/json
     response:
       status_code: 200
       body:
-        double: 10
+        double: !int "{output:d}"

--- a/example/timing/utils.py
+++ b/example/timing/utils.py
@@ -1,0 +1,20 @@
+import logging
+import time
+
+from tavern.util.testutils import inject_context
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@inject_context
+def timer_start(context):
+    context['timer_start'] = time.time()
+
+
+@inject_context
+def timer_stop(context):
+    start = context.pop('timer_start')
+    elapsed = time.time() - start
+
+    logger.info('request took %.3f seconds', elapsed)

--- a/example/timing/utils.py
+++ b/example/timing/utils.py
@@ -18,3 +18,9 @@ def timer_stop(context):
     elapsed = time.time() - start
 
     logger.info('request took %.3f seconds', elapsed)
+
+
+@inject_context
+def load_number(context):
+    context['variables']['input'] = 5
+    context['variables']['output'] = 10

--- a/tavern/core.py
+++ b/tavern/core.py
@@ -123,6 +123,7 @@ def run_test(in_file, test_spec, global_cfg):
 def run_stage(sessions, stage, tavern_box, test_block_config, test_context):
     name = stage["name"]
 
+    _run_stage_actions(stage, 'before', test_context)
     r = get_request_type(stage, test_block_config, sessions)
 
     tavern_box.update(request_vars=r.request_vars)
@@ -131,7 +132,6 @@ def run_stage(sessions, stage, tavern_box, test_block_config, test_context):
 
     # Kept for compatibility reasons
     delay(stage, "before")
-    _run_stage_actions(stage, 'before', test_context)
 
     logger.info("Running stage : %s", name)
     response = r.run()

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -110,6 +110,29 @@ mapping:
             type: bool
             required: false
 
+          re;(before|after):
+            type: seq
+            required: false
+            sequence:
+              - type: map
+                required: true
+                mapping:
+                  function:
+                    type: str
+                    required: true
+                  extra_args:
+                    type: seq
+                    required: false
+                    sequence:
+                      - type: any
+                        required: false
+                  extra_kwargs:
+                    type: map
+                    required: false
+                    mapping:
+                      re;(.*):
+                        type: str
+
           delay_before:
             type: float
             required: false

--- a/tavern/util/testutils.py
+++ b/tavern/util/testutils.py
@@ -1,0 +1,29 @@
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+
+def inject_context(func):
+    """Decorates the given function for passing the current test context. This
+    decorator should be used for callbacks in the before- and after stages
+    in a test.
+
+    Callbacks will receive a dictionary `context` as parameter which can be
+    used for saving values between function calls. A common use case would be
+    a setup and teardown pattern between before- and after-stage callbacks.
+
+    Additionally, the context contains the saved variables in the field
+    `variables`.
+    """
+    # pylint: disable=protected-access
+    func._tavern_inject_context = True
+    return func
+
+
+def delay(seconds):
+    """Helper function which delays current execution by :param:`seconds`
+    seconds."""
+
+    logger.debug("Delaying request for %d seconds", seconds)
+    time.sleep(seconds)


### PR DESCRIPTION
This PR adds support for custom before- and after handlers as proposed in #114 

An example which uses these handlers to measure response times has been added as well.

```
$ cd examples/timing
$ docker-compose build
$ docker-compose up -d
$ pytest -s
[...]
INFO:utils:request took 0.017 seconds
[...]
```

Currently `delay_before` and `delay_after` options still exist for compatibility reasons, one may either deprecate them for future versions or keep them for simplicity.