### PR TITLE
Add 'strict' argument to recursive key checking so dictionary key mis…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,9 @@ addopts =
     --cov-report term-missing
     --cov tavern
     --doctest-modules
-    -r xs -v --strict
+    -r xs
+    -vv
+    --strict
     -p no:logging
 norecursedirs =
     .git

--- a/tavern/_plugins/mqtt/response.py
+++ b/tavern/_plugins/mqtt/response.py
@@ -5,6 +5,7 @@ import time
 from tavern.schemas.extensions import get_wrapped_response_function
 from tavern.util import exceptions
 from tavern.response.base import BaseResponse
+from tavern.util.dict_util import check_keys_match_recursive
 
 try:
     LoadException = json.decoder.JSONDecodeError
@@ -93,6 +94,13 @@ class MQTTResponse(BaseResponse):
             if msg.payload != payload:
                 logger.warning("Got unexpected payload on topic '%s': '%s' (expected '%s')",
                     msg.topic, msg.payload, payload)
+
+                if json_payload:
+                    try:
+                        check_keys_match_recursive(payload, msg.payload, [])
+                    except exceptions.KeyMismatchError:
+                        # Just want to log the mismatch
+                        pass
             elif msg.topic != topic:
                 logger.warning("Got unexpected message in '%s' with payload '%s'",
                     msg.topic, msg.payload)

--- a/tavern/_plugins/rest/response.py
+++ b/tavern/_plugins/rest/response.py
@@ -214,7 +214,15 @@ class RestResponse(BaseResponse):
 
         logger.debug("Validating %s for %s", blockname, expected_block)
 
-        self.recurse_check_key_match(expected_block, block, blockname)
+        # 'strict' could be a list, in which case we only want to enable strict
+        # key checking for that specific bit of the response
+        test_strictness = self.test_block_config["strict"]
+        if isinstance(test_strictness, list):
+            block_strictness = (blockname in test_strictness)
+        else:
+            block_strictness = test_strictness
+
+        self.recurse_check_key_match(expected_block, block, blockname, block_strictness)
 
     def _save_value(self, key, to_check):
         """Save a value in the response for use in future tests

--- a/tavern/schemas/extensions.py
+++ b/tavern/schemas/extensions.py
@@ -159,3 +159,16 @@ def validate_json_with_extensions(value, rule_obj, path):
         raise BadSchemaError("Error at {} - expected a list or dict".format(path))
 
     return True
+
+
+def check_strict_key(value, rule_obj, path):
+    """Make sure the 'strict' key is either a bool or a list"""
+    # pylint: disable=unused-argument
+
+    if not isinstance(value, (bool, list)):
+        raise BadSchemaError("'strict' has to be either a boolean or a list")
+    elif isinstance(value, list):
+        if not set(["body", "headers", "redirect_query_params"]) >= set(value):
+            raise BadSchemaError("Invalid 'strict' keys passed: {}".format(value))
+
+    return True

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -32,6 +32,16 @@ mapping:
     required: true
     type: str
 
+  _xfail:
+    type: str
+    enum:
+      - verify
+      - run
+
+  strict:
+    func: check_strict_key
+    type: any
+
   includes:
     required: false
     type: seq
@@ -172,6 +182,10 @@ mapping:
             type: map
             required: false
             mapping:
+              strict:
+                func: check_strict_key
+                type: any
+
               status_code:
                 type: int
 

--- a/tests/integration/test_strict_key_checks.tavern.yaml
+++ b/tests/integration/test_strict_key_checks.tavern.yaml
@@ -1,0 +1,344 @@
+# This is what we expect:
+# top:
+#   Thing: value
+#   nested:
+#     doubly:
+#       inner: value
+# an_integer: 123
+# a_string: abc
+# a_bool: true
+
+---
+
+test_name: Test setting 'strict' to a string fails
+
+_xfail: verify
+
+strict: fkd
+
+stages:
+  - name: match top level
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+
+---
+
+test_name: Test setting 'strict' to a dict fails
+
+_xfail: verify
+
+strict:
+  body: true
+
+stages:
+  - name: match top level
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+
+---
+
+test_name: Test setting 'strict' to a list with invalid values fails
+
+_xfail: verify
+
+strict:
+  - blokergh
+
+stages:
+  - name: match top level
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+
+---
+
+test_name: Test legacy key matching against body works
+# should be removed in 1.0 when api changes
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: match with bool missing
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+      body:
+        top:
+          Thing: value
+          nested:
+            doubly:
+              inner: value
+        an_integer: 123
+        a_string: abc
+        # a_bool: true
+
+  - name: match with string missing
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+      body:
+        top:
+          Thing: value
+          nested:
+            doubly:
+              inner: value
+        an_integer: 123
+        # a_string: abc
+        a_bool: true
+
+  - name: match with int missing
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+      body:
+        top:
+          Thing: value
+          nested:
+            doubly:
+              inner: value
+        # an_integer: 123
+        a_string: abc
+        a_bool: true
+
+  - name: match with dict missing
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+      body:
+        # top:
+        #   Thing: value
+        #   nested:
+        #     doubly:
+        #       inner: value
+        an_integer: 123
+        a_string: abc
+        a_bool: true
+
+---
+
+test_name: Test strict key matching against body fails
+
+_xfail: run
+
+strict:
+  - body
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: match top level
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+      body:
+        top:
+          Thing: value
+          nested:
+            doubly:
+              inner: value
+        an_integer: 123
+        a_string: abc
+        # missing
+        # a_bool: true
+
+---
+
+test_name: Test strict key matching against body fails with dict missing when specified in test
+
+_xfail: run
+
+strict:
+  - body
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: match top level
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+      body:
+        # top:
+        #   Thing: value
+        #   nested:
+        #     doubly:
+        #       inner: value
+        an_integer: 123
+        a_string: abc
+        a_bool: true
+
+---
+
+test_name: Test strict key matching against body fails with dict missing when specified in stage
+
+_xfail: run
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: match top level
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      strict:
+        - body
+      status_code: 200
+      body:
+        # top:
+        #   Thing: value
+        #   nested:
+        #     doubly:
+        #       inner: value
+        an_integer: 123
+        a_string: abc
+        a_bool: true
+
+---
+
+test_name: Test strict key matching against headers with mismatch body passes
+# same as above, but changing 'strict' to only check headers should work
+
+strict:
+  - headers
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: match top level
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+      body:
+        top:
+          Thing: value
+          nested:
+            doubly:
+              inner: value
+        an_integer: 123
+        a_string: abc
+        # missing
+        # a_bool: true
+
+---
+
+test_name: Test strict key matching against exact body is fine when strict is specified in the test
+
+strict:
+  - body
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: match top level
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+      body:
+        top:
+          Thing: value
+          nested:
+            doubly:
+              inner: value
+        an_integer: 123
+        a_string: abc
+        a_bool: true
+
+---
+
+test_name: Test strict key matching against exact body is fine when strict is specified in the stage
+
+strict:
+  - body
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: match top level
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+      body:
+        top:
+          Thing: value
+          nested:
+            doubly:
+              inner: value
+        an_integer: 123
+        a_string: abc
+        a_bool: true
+
+---
+
+test_name: Test strict key matching works for specific test stages
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: match with one key missing
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+      body:
+        top:
+          Thing: value
+          nested:
+            doubly:
+              inner: value
+        an_integer: 123
+        a_string: abc
+        # a_bool: true
+
+  - name: match strictly for this stage
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      strict:
+        - body
+      status_code: 200
+      body:
+        top:
+          Thing: value
+          nested:
+            doubly:
+              inner: value
+        an_integer: 123
+        a_string: abc
+        a_bool: true
+
+  - name: match with one key missing again, without 'strict' cascading through stages
+    request:
+      url: "{host}/fake_dictionary"
+    response:
+      status_code: 200
+      body:
+        top:
+          Thing: value
+          nested:
+            doubly:
+              inner: value
+        # an_integer: 123
+        a_string: abc
+        a_bool: true

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,12 +12,13 @@ def fix_example_includes():
             "test_auth_token": "abc123",
             "code": "def456",
             "callback_url": "www.yahoo.co.uk",
-            "request_topic": "/abc"
+            "request_topic": "/abc",
         },
         "backends": {
             "mqtt": "paho-mqtt",
             "http": "requests",
-        }
+        },
+        "strict": True,
     }
 
     return includes.copy()


### PR DESCRIPTION
…matches can be ignored or made more strict

This adds a 'strict' argument which can be used from the config file, command line, in a test, or in a 'response' block for a test stage.

If not set, this will use the 'legacy' Tavern behaviour where top level keys are ignored but everything below is matched strictly. If set to False, it will ignore extra keys present in the response at all levels. If set to True, it will fail tests if the response does not exactly match the expected response.