### PR TITLE
Feature/fixtures

### DIFF
--- a/tavern/schemas/extensions.py
+++ b/tavern/schemas/extensions.py
@@ -166,6 +166,7 @@ def validate_status_code_is_int_or_list_of_ints(value, rule_obj, path):
 
 
 def check_usefixtures(value, rule_obj, path):
+    # pylint: disable=unused-argument
     err_msg = "'usefixtures' has to be a list with at least one item"
 
     if not isinstance(value, (list, tuple)):

--- a/tavern/schemas/extensions.py
+++ b/tavern/schemas/extensions.py
@@ -165,6 +165,18 @@ def validate_status_code_is_int_or_list_of_ints(value, rule_obj, path):
     return True
 
 
+def check_usefixtures(value, rule_obj, path):
+    err_msg = "'usefixtures' has to be a list with at least one item"
+
+    if not isinstance(value, (list, tuple)):
+        raise BadSchemaError(err_msg)
+
+    if not value:
+        raise BadSchemaError(err_msg)
+
+    return True
+
+
 def validate_data_key_with_ext_function(value, rule_obj, path):
     """Validate the 'data' key in a http request
 

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -44,6 +44,12 @@ mapping:
           skipif:
             type: str
 
+          usefixtures:
+            type: seq
+            sequence:
+              - type: str
+                required: true
+
           parametrize:
             type: map
             mapping:

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -46,6 +46,10 @@ mapping:
 
           usefixtures:
             type: seq
+            # Depending on what is actually given for usefixtures this function
+            # may or may not be called. I think this is a bug in pykwalify.
+            # See pytesthook.py
+            func: check_usefixtures
             sequence:
               - type: str
                 required: true

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -45,11 +45,10 @@ mapping:
             type: str
 
           usefixtures:
-            type: str
-            # type: seq
-            # sequence:
-            #   - type: str
-            #     required: true
+            type: seq
+            sequence:
+              - type: str
+                required: true
 
           parametrize:
             type: map

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -45,10 +45,11 @@ mapping:
             type: str
 
           usefixtures:
-            type: seq
-            sequence:
-              - type: str
-                required: true
+            type: str
+            # type: seq
+            # sequence:
+            #   - type: str
+            #     required: true
 
           parametrize:
             type: map

--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -364,7 +364,7 @@ class YamlItem(pytest.Item):
             elif isinstance(m.args, str):
                 mark_values = {m.args: self.funcargs[m.args]}
             else:
-                raise RuntimeError(("Can't handle 'usefixtures' spec of '{}'."
+                raise exceptions.BadSchemaError(("Can't handle 'usefixtures' spec of '{}'."
                     " There appears to be a bug in pykwalify so verification of"
                     " 'usefixtures' is broken - it should be a list of fixture"
                     " names").format(m.args))

--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -287,7 +287,7 @@ class YamlItem(pytest.Item):
         # pylint: disable=protected-access,attribute-defined-outside-init
         self.funcargs = {}
         fixtureinfo = self.session._fixturemanager.getfixtureinfo(
-            self, self.obj, self, funcargs=False)
+            self, self.obj, type(self), funcargs=False)
         self._fixtureinfo = fixtureinfo
         self.fixturenames = fixtureinfo.names_closure
         self._request = fixtures.FixtureRequest(self)

--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -364,7 +364,10 @@ class YamlItem(pytest.Item):
             elif isinstance(m.args, str):
                 mark_values = {m.args: self.funcargs[m.args]}
             else:
-                raise RuntimeError("Don't know how to handle {}".format(m.args))
+                raise RuntimeError(("Can't handle 'usefixtures' spec of '{}'."
+                    " There appears to be a bug in pykwalify so verification of"
+                    " 'usefixtures' is broken - it should be a list of fixture"
+                    " names").format(m.args))
 
             if any(mv in values for mv in mark_values):
                 logger.warning("Overriding value for %s", mark_values)

--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -5,6 +5,7 @@ import itertools
 import copy
 
 from _pytest._code.code import FormattedExcinfo
+from _pytest import fixtures
 import pytest
 import yaml
 from future.utils import raise_from
@@ -258,6 +259,7 @@ class YamlFile(pytest.File):
 
             try:
                 for i in self._generate_items(test_spec):
+                    i._initialise_fixture_attrs()
                     yield i
             except (TypeError, KeyError):
                 verify_tests(test_spec, load_plugins=False)
@@ -284,18 +286,16 @@ class YamlItem(pytest.Item):
 
         self.global_cfg = {}
 
-        self._initialise_fixture_attrs()
-
     def _initialise_fixture_attrs(self):
-        from _pytest import fixtures
         self.funcargs = {}
-        self._fixtureinfo = self.session._fixturemanager.getfixtureinfo(
-            self.parent, self.obj, self, funcargs=False)
+        fixtureinfo = self.session._fixturemanager.getfixtureinfo(
+            self, self.obj, self, funcargs=False)
+        self._fixtureinfo = fixtureinfo
+        self.fixturenames = fixtureinfo.names_closure
         self._request = fixtures.FixtureRequest(self)
 
     def setup(self):
         super(YamlItem, self).setup()
-        from _pytest import fixtures
         fixtures.fillfixtures(self)
 
     @property

--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -256,7 +256,7 @@ class YamlFile(pytest.File):
 
             try:
                 for i in self._generate_items(test_spec):
-                    i._initialise_fixture_attrs()
+                    i.initialise_fixture_attrs()
                     yield i
             except (TypeError, KeyError):
                 verify_tests(test_spec, load_plugins=False)
@@ -283,7 +283,8 @@ class YamlItem(pytest.Item):
 
         self.global_cfg = {}
 
-    def _initialise_fixture_attrs(self):
+    def initialise_fixture_attrs(self):
+        # pylint: disable=protected-access,attribute-defined-outside-init
         self.funcargs = {}
         fixtureinfo = self.session._fixturemanager.getfixtureinfo(
             self, self.obj, self, funcargs=False)
@@ -363,7 +364,7 @@ class YamlItem(pytest.Item):
             elif isinstance(m.args, str):
                 mark_values = {m.args: self.funcargs[m.args]}
             else:
-                raise RuntimeError("Don't know how to handle {}", m.args)
+                raise RuntimeError("Don't know how to handle {}".format(m.args))
 
             if any(mv in values for mv in mark_values):
                 logger.warning("Overriding value for %s", mark_values)

--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -284,6 +284,20 @@ class YamlItem(pytest.Item):
 
         self.global_cfg = {}
 
+        self._initialise_fixture_attrs()
+
+    def _initialise_fixture_attrs(self):
+        from _pytest import fixtures
+        self.funcargs = {}
+        self._fixtureinfo = self.session._fixturemanager.getfixtureinfo(
+            self.parent, self.obj, self, funcargs=False)
+        self._request = fixtures.FixtureRequest(self)
+
+    def setup(self):
+        super(YamlItem, self).setup()
+        from _pytest import fixtures
+        fixtures.fillfixtures(self)
+
     @property
     def obj(self):
         stages = ["{:d}: {:s}".format(i + 1, stage["name"]) for i, stage in enumerate(self.spec["stages"])]

--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -323,6 +323,7 @@ class YamlItem(pytest.Item):
                     # raise an exception at test verification.
                     logger.error("'usefixtures' was an invalid type (should"
                         " be a list of fixture names)")
+                    continue
 
             self.add_marker(pm)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,8 @@ def run_all():
     with open(os.path.join(current_dir, "logging.yaml"), "r") as spec_file:
         settings = yaml.load(spec_file)
         logging.config.dictConfig(settings)
+
+
+@pytest.fixture
+def abc():
+    return "abc-fixture-value"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,8 @@ def run_all():
 @pytest.fixture
 def abc():
     return "abc-fixture-value"
+
+
+@pytest.fixture(name="def")
+def sdkofsok(abc):
+    return abc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,17 @@ def run_all():
 
 
 @pytest.fixture
-def abc():
+def str_fixture():
     return "abc-fixture-value"
 
 
-@pytest.fixture(name="def")
-def sdkofsok(abc):
-    return abc
+@pytest.fixture(name="yield_str_fixture")
+def sdkofsok(str_fixture):
+    yield str_fixture
+
+
+@pytest.fixture(name="yielder")
+def bluerhug():
+    # This doesn't really do anything at the moment. In future it might yield
+    # the result or something, but it's a bit difficult to do at the moment.
+    response = (yield "hello")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,20 +10,3 @@ def run_all():
     with open(os.path.join(current_dir, "logging.yaml"), "r") as spec_file:
         settings = yaml.load(spec_file)
         logging.config.dictConfig(settings)
-
-
-@pytest.fixture
-def str_fixture():
-    return "abc-fixture-value"
-
-
-@pytest.fixture(name="yield_str_fixture")
-def sdkofsok(str_fixture):
-    yield str_fixture
-
-
-@pytest.fixture(name="yielder")
-def bluerhug():
-    # This doesn't really do anything at the moment. In future it might yield
-    # the result or something, but it's a bit difficult to do at the moment.
-    response = (yield "hello")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+@pytest.fixture
+def str_fixture():
+    return "abc-fixture-value"
+
+
+@pytest.fixture(name="yield_str_fixture")
+def sdkofsok(str_fixture):
+    yield str_fixture
+
+
+@pytest.fixture(name="yielder")
+def bluerhug(request):
+    # This doesn't really do anything at the moment. In future it might yield
+    # the result or something, but it's a bit difficult to do at the moment.
+    response = (yield "hello")

--- a/tests/integration/test_fixtures.tavern.yaml
+++ b/tests/integration/test_fixtures.tavern.yaml
@@ -6,14 +6,8 @@ includes:
   - !include common.yaml
 
 marks:
-  - parametrize:
-      key: to_send
-      vals:
-        - abc
-        - def
-        - "123"
-  - usefixtures:
-      - "anc"
+  - usefixtures: def
+  - usefixtures: abc
 
 stages:
   - name: Echo back a unicode value and make sure it matches
@@ -21,8 +15,8 @@ stages:
       url: "{host}/echo"
       method: POST
       json:
-        value: "{to_send}"
+        value: "abc"
     response:
       status_code: 200
       body:
-        value: "{to_send}"
+        value: "def"

--- a/tests/integration/test_fixtures.tavern.yaml
+++ b/tests/integration/test_fixtures.tavern.yaml
@@ -6,8 +6,9 @@ includes:
   - !include common.yaml
 
 marks:
-  - usefixtures: abc
-  # - usefixtures: def
+  - usefixtures:
+      - abc
+      - def
 
 stages:
   - name: Echo back a unicode value and make sure it matches
@@ -19,4 +20,4 @@ stages:
     response:
       status_code: 200
       body:
-        value: "{abc}"
+        value: "{def}"

--- a/tests/integration/test_fixtures.tavern.yaml
+++ b/tests/integration/test_fixtures.tavern.yaml
@@ -11,8 +11,8 @@ marks:
   # Breaks validation somehow...?
   - usefixtures: {}
   - usefixtures:
-      - abc
-      - def
+      - str_fixture
+      - yield_str_fixture
 
 stages:
   - name: Echo back a unicode value and make sure it matches
@@ -20,11 +20,11 @@ stages:
       url: "{host}/echo"
       method: POST
       json:
-        value: "{abc}"
+        value: "{str_fixture}"
     response:
       status_code: 200
       body:
-        value: "{def}"
+        value: "{yield_str_fixture}"
 
 ---
 
@@ -36,7 +36,7 @@ includes:
 _xfail: verify
 
 marks:
-  - usefixtures: abc
+  - usefixtures: str_fixture
 
 stages:
   - name: Echo back a unicode value and make sure it matches
@@ -44,11 +44,11 @@ stages:
       url: "{host}/echo"
       method: POST
       json:
-        value: "{abc}"
+        value: "{str_fixture}"
     response:
       status_code: 200
       body:
-        value: "{def}"
+        value: "{yield_str_fixture}"
 
 ---
 
@@ -59,8 +59,8 @@ includes:
 
 marks:
   - usefixtures:
-      - abc
-      - def
+      - str_fixture
+      - yield_str_fixture
 
 stages:
   - name: Echo back a unicode value and make sure it matches
@@ -68,8 +68,33 @@ stages:
       url: "{host}/echo"
       method: POST
       json:
-        value: "{abc}"
+        value: "{str_fixture}"
     response:
       status_code: 200
       body:
-        value: "{def}"
+        value: "{yield_str_fixture}"
+
+---
+
+test_name: Test yielding fixture
+
+includes:
+  - !include common.yaml
+
+marks:
+  - usefixtures:
+      - yielder
+      - str_fixture
+      - yield_str_fixture
+
+stages:
+  - name: Echo back a unicode value and make sure it matches
+    request:
+      url: "{host}/echo"
+      method: POST
+      json:
+        value: "{str_fixture}"
+    response:
+      status_code: 200
+      body:
+        value: "{yield_str_fixture}"

--- a/tests/integration/test_fixtures.tavern.yaml
+++ b/tests/integration/test_fixtures.tavern.yaml
@@ -1,0 +1,28 @@
+---
+
+test_name: Test do a thing
+
+includes:
+  - !include common.yaml
+
+marks:
+  - parametrize:
+      key: to_send
+      vals:
+        - abc
+        - def
+        - "123"
+  - usefixtures:
+      - "anc"
+
+stages:
+  - name: Echo back a unicode value and make sure it matches
+    request:
+      url: "{host}/echo"
+      method: POST
+      json:
+        value: "{to_send}"
+    response:
+      status_code: 200
+      body:
+        value: "{to_send}"

--- a/tests/integration/test_fixtures.tavern.yaml
+++ b/tests/integration/test_fixtures.tavern.yaml
@@ -1,6 +1,32 @@
 ---
 
-test_name: Test do a thing
+test_name: Test empty usefixtures errors
+
+includes:
+  - !include common.yaml
+
+_xfail: verify
+
+marks:
+  - usefixtures: {}
+  - usefixtures:
+      - abc
+      - def
+
+stages:
+  - name: Echo back a unicode value and make sure it matches
+    request:
+      url: "{host}/echo"
+      method: POST
+      json:
+        value: "{abc}"
+    response:
+      status_code: 200
+      body:
+        value: "{def}"
+---
+
+test_name: Test usefixtures
 
 includes:
   - !include common.yaml

--- a/tests/integration/test_fixtures.tavern.yaml
+++ b/tests/integration/test_fixtures.tavern.yaml
@@ -6,8 +6,8 @@ includes:
   - !include common.yaml
 
 marks:
-  - usefixtures: def
   - usefixtures: abc
+  # - usefixtures: def
 
 stages:
   - name: Echo back a unicode value and make sure it matches
@@ -15,8 +15,8 @@ stages:
       url: "{host}/echo"
       method: POST
       json:
-        value: "abc"
+        value: "{abc}"
     response:
       status_code: 200
       body:
-        value: "def"
+        value: "{abc}"

--- a/tests/integration/test_fixtures.tavern.yaml
+++ b/tests/integration/test_fixtures.tavern.yaml
@@ -8,6 +8,7 @@ includes:
 _xfail: verify
 
 marks:
+  # Breaks validation somehow...?
   - usefixtures: {}
   - usefixtures:
       - abc
@@ -24,6 +25,31 @@ stages:
       status_code: 200
       body:
         value: "{def}"
+
+---
+
+test_name: Test usefixtures being a mapping errors
+
+includes:
+  - !include common.yaml
+
+_xfail: verify
+
+marks:
+  - usefixtures: abc
+
+stages:
+  - name: Echo back a unicode value and make sure it matches
+    request:
+      url: "{host}/echo"
+      method: POST
+      json:
+        value: "{abc}"
+    response:
+      status_code: 200
+      body:
+        value: "{def}"
+
 ---
 
 test_name: Test usefixtures

--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -37,6 +37,8 @@ commands =
     mqtt: tavern-ci --stdout test_mqtt.tavern.yaml --no-cov
     mqtt: python -c "from tavern.core import run; run('test_mqtt.tavern.yaml', pytest_args=['--no-cov'])"
 
+    generic: tavern-ci --stdout test_fixtures.tavern.yaml --no-cov
+    generic: python -c "from tavern.core import run; run('test_fixtures.tavern.yaml', pytest_args=['--no-cov'])"
     generic: tavern-ci --stdout test_env_var_format.tavern.yaml --no-cov
     generic: python -c "from tavern.core import run; run('test_env_var_format.tavern.yaml', pytest_args=['--no-cov'])"
     generic: tavern-ci --stdout test_files.tavern.yaml --no-cov


### PR DESCRIPTION
This just reuses the `usefixtures` mark so you can specify a list of fixture names to use for that test. This can be used with 'yielding' fixtures to run stuff before and after the test stage, and the return value of any fixtures is added to the variables for that test. For example, this fixture:

```python
@pytest.fixture(name="json_val")
def get_json_val():
    return "abc123"
```

will be put into the variables as `{"json_val": "abc123"}` for use in formatting.