### PR TITLE
Type convert boolean variables correctly (closes #149)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,3 +12,4 @@ ignore-imports=yes
 
 [TYPECHECK]
 ignored-classes=RememberComposer
+ignored-modules=distutils

--- a/tavern/util/loader.py
+++ b/tavern/util/loader.py
@@ -229,10 +229,24 @@ class FloatToken(TypeConvertToken):
     yaml_tag = "!float"
     constructor = float
 
+class BoolLiteralEval(object):
+    """Using `bool` as a constructor will evaluate all strings to `True`.
+    Using `ast.literal_eval` may result in other datatypes being returned.
+    This constructor returns a boolean given a boolean string representation.
+
+    See discussion here: https://stackoverflow.com/a/21732186/9923936
+    """
+    def __new__(cls, s):
+        if s == 'True':
+            return True
+        elif s == 'False':
+            return False
+        else:
+            raise ValueError("Cannot literally eval {} to a bool".format(s))
 
 class BoolToken(TypeConvertToken):
     yaml_tag = "!bool"
-    constructor = bool
+    constructor = BoolLiteralEval
 
 
 # Sort-of hack to try and avoid future API changes

--- a/tavern/util/loader.py
+++ b/tavern/util/loader.py
@@ -1,5 +1,6 @@
 # https://gist.github.com/joshbode/569627ced3076931b02f
 
+from distutils.util import strtobool
 import logging
 import uuid
 import os.path
@@ -229,24 +230,17 @@ class FloatToken(TypeConvertToken):
     yaml_tag = "!float"
     constructor = float
 
-class BoolLiteralEval(object):
-    """Using `bool` as a constructor will evaluate all strings to `True`.
-    Using `ast.literal_eval` may result in other datatypes being returned.
-    This constructor returns a boolean given a boolean string representation.
 
-    See discussion here: https://stackoverflow.com/a/21732186/9923936
-    """
+class StrToBoolConstructor(object):
+    """Using `bool` as a constructor directly will evaluate all strings to `True`."""
+
     def __new__(cls, s):
-        if s == 'True':
-            return True
-        elif s == 'False':
-            return False
-        else:
-            raise ValueError("Cannot literally eval {} to a bool".format(s))
+        return bool(strtobool(s))
+
 
 class BoolToken(TypeConvertToken):
     yaml_tag = "!bool"
-    constructor = BoolLiteralEval
+    constructor = StrToBoolConstructor 
 
 
 # Sort-of hack to try and avoid future API changes

--- a/tavern/util/loader.py
+++ b/tavern/util/loader.py
@@ -240,7 +240,7 @@ class StrToBoolConstructor(object):
 
 class BoolToken(TypeConvertToken):
     yaml_tag = "!bool"
-    constructor = StrToBoolConstructor 
+    constructor = StrToBoolConstructor
 
 
 # Sort-of hack to try and avoid future API changes

--- a/tests/integration/server.py
+++ b/tests/integration/server.py
@@ -114,22 +114,22 @@ def expect_type():
     dtype = body.get("dtype")
     dvalue = body.get("dvalue")
 
+    status = "OK"
+    code = 200
+
     if not value and dtype and dvalue:
-        return jsonify({
-            "status": "Missing expected type or value"
-        }), 400
+        status = "Missing expected type or value"
+        code = 400
 
     if str(type(value)) != "<class '{}'>".format(dtype):
-        return jsonify({
-            "status": "Unexpected type: '{}'".format(str(type(value)))
-        }), 400
+        status = "Unexpected type: '{}'".format(str(type(value)))
+        code = 400
 
     if value != dvalue:
-        return jsonify({
-            "status": "Unexpected value: '{}'".format(value)
-        }), 400
+        status = "Unexpected value: '{}'".format(value)
+        code = 400
 
-    return "", 200
+    return jsonify({"status": status}), code
 
 
 @app.route("/status_code_return", methods=["POST"])

--- a/tests/integration/server.py
+++ b/tests/integration/server.py
@@ -112,12 +112,22 @@ def expect_type():
     body = request.get_json()
     value = body.get("value")
     dtype = body.get("dtype")
+    dvalue = body.get("dvalue")
 
-    if not value and dtype:
-        return "", 400
+    if not value and dtype and dvalue:
+        return jsonify({
+            "status": "Missing expected type or value"
+        }), 400
 
     if str(type(value)) != "<class '{}'>".format(dtype):
-        return "", 400
+        return jsonify({
+            "status": "Unexpected type: '{}'".format(str(type(value)))
+        }), 400
+
+    if value != dvalue:
+        return jsonify({
+            "status": "Unexpected value: '{}'".format(value)
+        }), 400
 
     return "", 200
 

--- a/tests/integration/test_typetokens.tavern.yaml
+++ b/tests/integration/test_typetokens.tavern.yaml
@@ -200,6 +200,7 @@ stages:
       json:
         value: !bool "{v_bool}"
         dtype: bool
+        dvalue: False
     response:
       status_code: 200
 
@@ -212,6 +213,7 @@ stages:
   #     json:
   #       value: !bool "true"
   #       dtype: bool
+  #       dvalue: True
   #   response:
   #     status_code: 200
 
@@ -291,6 +293,7 @@ stages:
       json:
         value: !int "{v_int}"
         dtype: int
+        dvalue: 123
     response:
       status_code: 200
 
@@ -301,6 +304,7 @@ stages:
       json:
         value: !int "1"
         dtype: int
+        dvalue: 1
     response:
       status_code: 200
 
@@ -313,6 +317,7 @@ stages:
   #     json:
   #       value: !int "{v_float}"
   #       dtype: int
+  #       dvalue: 123
   #   response:
   #     status_code: 200
 
@@ -331,6 +336,7 @@ stages:
       json:
         value: !float "{v_int}"
         dtype: float
+        dvalue: 123.0
     response:
       status_code: 200
 
@@ -341,6 +347,7 @@ stages:
       json:
         value: !float "1"
         dtype: float
+        dvalue: 1
     response:
       status_code: 200
 
@@ -351,6 +358,7 @@ stages:
       json:
         value: !float "{v_float}"
         dtype: float
+        dvalue: 4.56
     response:
       status_code: 200
 
@@ -361,6 +369,7 @@ stages:
       json:
         value: !float "5.67"
         dtype: float
+        dvalue: 5.67
     response:
       status_code: 200
 
@@ -393,5 +402,6 @@ stages:
       json:
         value: !float "{saved_float_value}"
         dtype: float
+        dvalue: 123.0
     response:
       status_code: 200

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -278,10 +278,13 @@ def fix_test_yaml():
 
 
 class TestCustomTokens:
+    def assert_type_value(self, test_value, expected_type, expected_value):
+        assert isinstance(test_value, expected_type)
+        assert test_value == expected_value
 
     def test_conversion(self, test_yaml):
         stages = yaml.load(test_yaml, Loader=IncludeLoader)['stages'][0]
 
-        assert isinstance(stages['request']['json']['number'], int)
-        assert isinstance(stages['response']['body']['double'], float)
-        assert isinstance(stages['request']['json']['return_float'], bool)
+        self.assert_type_value(stages['request']['json']['number'], int, 5)
+        self.assert_type_value(stages['response']['body']['double'], float, 10.0)
+        self.assert_type_value(stages['request']['json']['return_float'], bool, True)

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -263,6 +263,7 @@ def fix_test_yaml():
         request:
           url: http://localhost:5000/double
           json:
+            is_sensitive: !bool "False"
             number: !int '5'
             return_float: !bool "True"
           method: POST
@@ -288,3 +289,4 @@ class TestCustomTokens:
         self.assert_type_value(stages['request']['json']['number'], int, 5)
         self.assert_type_value(stages['response']['body']['double'], float, 10.0)
         self.assert_type_value(stages['request']['json']['return_float'], bool, True)
+        self.assert_type_value(stages['request']['json']['is_sensitive'], bool, False)


### PR DESCRIPTION
See #149 for issue details.

This PR:
- adds failing tests that show `!bool` type conversion is incorrect
- implements a fix for `!bool` using a custom `bool` constructor class

The custom bool constructor is similar to the builtin `bool` constructor as per [PEP 285](https://www.python.org/dev/peps/pep-0285/#specification), and as discussed [here](https://stackoverflow.com/a/21732186/9923936)