### PR TITLE
Add !raw custom yaml token

### DIFF
--- a/tavern/util/loader.py
+++ b/tavern/util/loader.py
@@ -5,7 +5,6 @@ import logging
 import uuid
 import os.path
 import pytest
-import re
 from future.utils import raise_from
 
 import yaml
@@ -248,7 +247,7 @@ class StrToRawConstructor(object):
     """Used when we want to ignore brace formatting syntax"""
 
     def __new__(cls, s):
-        return re.sub(r"([}{])", r"\1\1", s)
+        return s.replace("{", "{{").replace("}", "}}")
 
 
 class RawStrToken(TypeConvertToken):

--- a/tavern/util/loader.py
+++ b/tavern/util/loader.py
@@ -5,6 +5,7 @@ import logging
 import uuid
 import os.path
 import pytest
+import re
 from future.utils import raise_from
 
 import yaml
@@ -241,6 +242,18 @@ class StrToBoolConstructor(object):
 class BoolToken(TypeConvertToken):
     yaml_tag = "!bool"
     constructor = StrToBoolConstructor
+
+
+class StrToRawConstructor(object):
+    """Used when we want to ignore brace formatting syntax"""
+
+    def __new__(cls, s):
+        return re.sub(r"([}{])", r"\1\1", s)
+
+
+class RawStrToken(TypeConvertToken):
+    yaml_tag = "!raw"
+    constructor = StrToRawConstructor
 
 
 # Sort-of hack to try and avoid future API changes

--- a/tests/integration/test_typetokens.tavern.yaml
+++ b/tests/integration/test_typetokens.tavern.yaml
@@ -408,25 +408,6 @@ stages:
 
 ---
 
-test_name: Test not converting a raw string (ignore variable like syntax)
-
-includes:
-  - !include common.yaml
-
-stages:
-  - name: Do not convert raw string
-    request:
-      url: "{host}/expect_dtype"
-      method: POST
-      json:
-        value: '{"query": "{ val1 { val2 { val3 { val4, val5 } } } }"}'
-        dtype: str
-        dvalue: '{"query": "{ val1 { val2 { val3 { val4, val5 } } } }"}'
-    response:
-      status_code: 200
-
----
-
 test_name: Ignore variable syntax with double braces
 
 includes:
@@ -439,6 +420,25 @@ stages:
       method: POST
       json:
         value: '{{"query": "{{ val1 {{ val2 {{ val3 {{ val4, val5 }} }} }} }}"}}'
+        dtype: str
+        dvalue: '{{"query": "{{ val1 {{ val2 {{ val3 {{ val4, val5 }} }} }} }}"}}'
+    response:
+      status_code: 200
+
+---
+
+test_name: Test not converting a raw string (ignore variable like syntax)
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: Do not convert raw string
+    request:
+      url: "{host}/expect_dtype"
+      method: POST
+      json:
+        value: !raw '{"query": "{ val1 { val2 { val3 { val4, val5 } } } }"}'
         dtype: str
         dvalue: '{{"query": "{{ val1 {{ val2 {{ val3 {{ val4, val5 }} }} }} }}"}}'
     response:

--- a/tests/integration/test_typetokens.tavern.yaml
+++ b/tests/integration/test_typetokens.tavern.yaml
@@ -405,3 +405,41 @@ stages:
         dvalue: 123.0
     response:
       status_code: 200
+
+---
+
+test_name: Test not converting a raw string (ignore variable like syntax)
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: Do not convert raw string
+    request:
+      url: "{host}/expect_dtype"
+      method: POST
+      json:
+        value: '{"query": "{ val1 { val2 { val3 { val4, val5 } } } }"}'
+        dtype: str
+        dvalue: '{"query": "{ val1 { val2 { val3 { val4, val5 } } } }"}'
+    response:
+      status_code: 200
+
+---
+
+test_name: Ignore variable syntax with double braces
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: Do not convert double braces
+    request:
+      url: "{host}/expect_dtype"
+      method: POST
+      json:
+        value: '{{"query": "{{ val1 {{ val2 {{ val3 {{ val4, val5 }} }} }} }}"}}'
+        dtype: str
+        dvalue: '{{"query": "{{ val1 {{ val2 {{ val3 {{ val4, val5 }} }} }} }}"}}'
+    response:
+      status_code: 200

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -264,6 +264,7 @@ def fix_test_yaml():
           url: http://localhost:5000/double
           json:
             is_sensitive: !bool "False"
+            raw_str: !raw '{"query": "{ val1 { val2 { val3 { val4, val5 } } } }"}'
             number: !int '5'
             return_float: !bool "True"
           method: POST
@@ -290,3 +291,8 @@ class TestCustomTokens:
         self.assert_type_value(stages['response']['body']['double'], float, 10.0)
         self.assert_type_value(stages['request']['json']['return_float'], bool, True)
         self.assert_type_value(stages['request']['json']['is_sensitive'], bool, False)
+        self.assert_type_value(
+            stages['request']['json']['raw_str'],
+            str,
+            '{{"query": "{{ val1 {{ val2 {{ val3 {{ val4, val5 }} }} }} }}"}}'
+        )


### PR DESCRIPTION
The `!raw` custom yaml TypeToken escapes curly braces in strings, preventing variable substitution later during testrunning (see #117 ).

This PR:
- adds a new yaml TypeToken, `!raw`
- adds unit tests showing
  - string [brace doubling to escape formatting](https://docs.python.org/3.7/library/string.html#format-string-syntax)
  - correct type of `str`
- adds integration tests showing
  - no `missing variable` errors
  - correct type of `str`