### PR TITLE
Support for reusable stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,10 @@ tags
 # Sublimetext
 *.sublime-*
 
+# Vim
+*.swp
+*.swo
+
 # Pycharm
 .idea
 

--- a/example/components/Dockerfile
+++ b/example/components/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.5-alpine
+
+RUN pip install flask pyjwt
+
+COPY server.py /
+
+ENV FLASK_APP=/server.py
+
+CMD ["flask", "run", "--host=0.0.0.0"]

--- a/example/components/Dockerfile
+++ b/example/components/Dockerfile
@@ -6,4 +6,4 @@ COPY server.py /
 
 ENV FLASK_APP=/server.py
 
-CMD ["flask", "run", "--host=0.0.0.0"]
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5009"]

--- a/example/components/common.yaml
+++ b/example/components/common.yaml
@@ -1,0 +1,7 @@
+---
+name: Test loading external componenets
+description:
+  Test the ability to test components from external YAML files.
+
+variables:
+  service: "http://localhost:5000"

--- a/example/components/common.yaml
+++ b/example/components/common.yaml
@@ -4,4 +4,4 @@ description:
   Test the ability to test components from external YAML files.
 
 variables:
-  service: "http://localhost:5000"
+  service: "http://localhost:5009"

--- a/example/components/components.md
+++ b/example/components/components.md
@@ -1,0 +1,16 @@
+# Load external components (stage) example
+
+In this example we need to authenticate for every request to the server. Every
+test file needs to do this. To avoid duplication, we do the following:
+
+- Have server with /ping and /hello endpoints, both requiring JWT to complete
+  the request.
+- Create components/auth_stage.yaml - this defines a stage that logs in *and*
+  saves the token for subsequent stages.
+- Create two tests, one for each distinct endpoint. Each test will *include* the
+  external components (authentication/login stage), and then execute the stage
+  where we need it.
+
+
+This allows stages to be defined outside of the context of a test spec, and be
+included in many test specs, in different files.

--- a/example/components/components/auth_stage.yaml
+++ b/example/components/components/auth_stage.yaml
@@ -1,0 +1,30 @@
+# componenets/stage_auth.yaml
+---
+
+name: Authentication stage
+description:
+  Reusable test stage for authentication
+
+variables:
+  user:
+    user: test-user
+    pass: correct-password
+
+stages:
+  - id: login_get_token
+    name: Login and acquire token
+    request:
+      url: "{service:s}/login"
+      json:
+        user: "{user.user:s}"
+        password: "{user.pass:s}"
+      method: POST
+      headers:
+        content-type: application/json
+    response:
+      status_code: 200
+      headers:
+        content-type: application/json
+      save:
+        body:
+          test_login_token: token

--- a/example/components/docker-compose.yaml
+++ b/example/components/docker-compose.yaml
@@ -1,0 +1,10 @@
+---
+version: '2'
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "5000:5000"

--- a/example/components/docker-compose.yaml
+++ b/example/components/docker-compose.yaml
@@ -7,4 +7,4 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "5000:5000"
+      - "5009:5009"

--- a/example/components/server.py
+++ b/example/components/server.py
@@ -1,0 +1,68 @@
+import sqlite3
+import datetime
+import functools
+from flask import Flask, jsonify, request, g
+import jwt
+
+
+app = Flask(__name__)
+
+
+SECRET = "CGQgaG7GYvTcpaQZqosLy5"
+DATABASE = "/tmp/test_db"
+SERVERNAME = "testserver"
+
+
+@app.route("/login", methods=["POST"])
+def login():
+    r = request.get_json()
+
+    if r["user"] != "test-user" or r["password"] != "correct-password":
+        return jsonify({"error": "Incorrect username/password"}), 401
+
+    payload = {
+        "sub": "test-user",
+        "aud": SERVERNAME,
+        "exp": datetime.datetime.now() + datetime.timedelta(hours=1)
+    }
+
+    token = jwt.encode(payload, SECRET, algorithm="HS256").decode("utf8")
+
+    return jsonify({"token": token})
+
+
+def requires_jwt(endpoint):
+    """ Makes sure a jwt is in the request before accepting it """
+
+    @functools.wraps(endpoint)
+    def check_auth_call(*args, **kwargs):
+        token = request.headers.get("Authorization")
+
+        # check token is present
+        if not token:
+            return jsonify({"error": "No token"}), 401
+
+        token_type, token = token.split(" ")
+
+        if token_type.lower() != "bearer":
+            return jsonify({"error": "Wrong token type"}), 401
+
+        try:
+            jwt.decode(token, SECRET, audience=SERVERNAME, algorithms=["HS256"])
+        except:
+            return jsonify({"error": "Invalid token"}), 401
+
+        return endpoint(*args, **kwargs)
+
+    return check_auth_call
+
+@app.route("/ping", methods=["GET"])
+@requires_jwt
+def ping():
+    return jsonify({"data": "pong"}), 200
+
+@app.route("/hello/<name>", methods=["GET"])
+@requires_jwt
+def hello(name):
+    return jsonify({"data": "Hello, {}".format(name)}), 200
+

--- a/example/components/test_hello.tavern.yaml
+++ b/example/components/test_hello.tavern.yaml
@@ -1,0 +1,30 @@
+---
+
+test_name: Test authenticated /hello
+
+includes:
+  - !include common.yaml
+  - !include components/auth_stage.yaml
+
+stages:
+  - name: Unauthenticated /hello
+    request:
+      url: "{service:s}/hello/Jim"
+      method: GET
+    response:
+      status_code: 401
+  - type: ref
+    id: login_get_token
+  - name: Authenticated /hello
+    request:
+      url: "{service:s}/hello/Jim"
+      method: GET
+      headers:
+        Content-Type: application/json
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      headers:
+        content-type: application/json
+      body:
+        data: "Hello, Jim"

--- a/example/components/test_ping.tavern.yaml
+++ b/example/components/test_ping.tavern.yaml
@@ -1,0 +1,30 @@
+---
+
+test_name: Test authenticated /ping
+
+includes:
+  - !include common.yaml
+  - !include components/auth_stage.yaml
+
+stages:
+  - name: Unauthenticated /ping
+    request:
+      url: "{service:s}/ping"
+      method: GET
+    response:
+      status_code: 401
+  - type: ref
+    id: login_get_token
+  - name: Authenticated /ping
+    request:
+      url: "{service:s}/ping"
+      method: GET
+      headers:
+        Content-Type: application/json
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      headers:
+        content-type: application/json
+      body:
+        data: pong

--- a/tavern/core.py
+++ b/tavern/core.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 import os
+from copy import deepcopy
 
 import pytest
 
@@ -17,6 +18,29 @@ from .schemas.files import wrapfile
 
 logger = logging.getLogger(__name__)
 
+def _resolve_test_stages(test_spec, available_stages):
+    # Need to get a final list of stages in the tests (resolving refs)
+    test_stages = []
+    for raw_stage in test_spec["stages"]:
+        stage = raw_stage
+        if "type" in stage:
+            if stage["type"] == "ref":
+                if "id" in stage:
+                    ref_id = stage["id"]
+                    if ref_id in available_stages:
+                        # Make sure nothing downstream can change the globally
+                        # defined stage. Just give the test a local copy.
+                        stage = deepcopy(available_stages[ref_id])
+                        logger.debug("found stage reference: %s", ref_id)
+                    else:
+                        logger.error("Skip stage: unknown stage referenced: %s", ref_id)
+                        continue
+                else:
+                    logger.error("Skip stage: 'ref' type must specify 'id'")
+                    continue
+        test_stages.append(stage)
+
+    return test_stages
 
 def run_test(in_file, test_spec, global_cfg):
     """Run a single tavern test
@@ -56,11 +80,16 @@ def run_test(in_file, test_spec, global_cfg):
         logger.warning("Empty test block in %s", in_file)
         return
 
+    available_stages = {}
     if test_spec.get("includes"):
         for included in test_spec["includes"]:
             if "variables" in included:
                 formatted_include = format_keys(included["variables"], {"tavern": tavern_box})
                 test_block_config["variables"].update(formatted_include)
+
+            if "stages" in included:
+                for stage in included["stages"]:
+                    available_stages[stage["id"]] = stage
 
     test_block_name = test_spec["test_name"]
 
@@ -70,6 +99,7 @@ def run_test(in_file, test_spec, global_cfg):
     logger.info("Running test : %s", test_block_name)
 
     with ExitStack() as stack:
+        test_spec["stages"] = _resolve_test_stages(test_spec, available_stages)
         sessions = get_extra_sessions(test_spec, test_block_config)
 
         for name, session in sessions.items():

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -25,6 +25,176 @@ schema;any_map_or_list_with_ext_function:
   type: any
   required: false
 
+schema;stage:
+  type: map
+  required: true
+  mapping:
+    id:
+      type: str
+      required: false
+    name:
+      type: str
+      required: true
+      unique: true
+
+    skip:
+      type: bool
+      required: false
+
+    only:
+      type: bool
+      required: false
+
+    delay_before:
+      type: float
+      required: false
+    delay_after:
+      type: float
+      required: false
+
+    mqtt_publish:
+      type: map
+      required: false
+      mapping:
+        topic:
+          type: str
+          required: true
+        payload:
+          # Only a string
+          type: str
+          required: false
+        json:
+          include: any_map_or_list_with_ext_function
+        qos:
+          type: int
+          required: false
+    mqtt_response:
+      type: map
+      required: false
+      mapping:
+        topic:
+          type: str
+          required: true
+        payload:
+          type: any
+          required: false
+        json:
+          include: any_map_or_list_with_ext_function
+        timeout:
+          type: float
+          required: false
+        qos:
+          type: int
+          required: false
+          enum:
+            - 0
+            - 1
+            - 2
+
+    request:
+      type: map
+      required: false
+      mapping:
+        url:
+          type: str
+          required: true
+
+        re;(params|headers):
+          include: any_map_with_ext_function
+
+        data:
+          type: any
+          func: validate_data_key_with_ext_function
+          required: false
+
+        stream:
+          type: bool
+          required: false
+
+        auth:
+          func: validate_extensions
+          type: seq
+          required: false
+          sequence:
+            - type: str
+              required: true
+            - type: str
+              required: true
+
+        json:
+          include: any_map_or_list_with_ext_function
+
+        files:
+          required: false
+          type: map
+          mapping:
+            re;(.*):
+              type: str
+
+        method:
+          type: str
+          enum:
+            - GET
+            - PUT
+            - POST
+            - DELETE
+            - PATCH
+            - OPTIONS
+            - HEAD
+
+        verify:
+          type: bool
+          required: false
+
+        meta:
+          type: seq
+          required: false
+          sequence:
+            - type: str
+              unique: true
+
+    response:
+      type: map
+      required: false
+      mapping:
+        strict:
+          func: check_strict_key
+          type: any
+
+        status_code:
+          type: any
+          func: validate_status_code_is_int_or_list_of_ints
+
+        cookies:
+          type: seq
+          required: false
+          sequence:
+            - type: str
+              unique: true
+
+        re;(headers|redirect_query_params):
+          include: any_map_with_ext_function
+
+        body:
+          include: any_map_or_list_with_ext_function
+
+        save:
+          include: any_map_with_ext_function
+          mapping:
+            re;(\$ext|body|headers|redirect_query_params):
+              type: any
+
+schema;stage_ref:
+  type: map
+  required: true
+  mapping:
+    type:
+      required: true
+      type: str
+      pattern: ^ref$
+    id:
+      required: true
+      type: str
 
 type: map
 mapping:
@@ -100,161 +270,15 @@ mapping:
               re;(.*):
                 type: any
 
+          stages:
+            type: seq
+            required: false
+            sequence:
+              - include: stage
+
   stages:
     type: seq
     required: true
     sequence:
-      - type: map
-        required: true
-        mapping:
-          name:
-            type: str
-            required: true
-            unique: true
-
-          skip:
-            type: bool
-            required: false
-
-          only:
-            type: bool
-            required: false
-
-          delay_before:
-            type: float
-            required: false
-          delay_after:
-            type: float
-            required: false
-
-          mqtt_publish:
-            type: map
-            required: false
-            mapping:
-              topic:
-                type: str
-                required: true
-              payload:
-                # Only a string
-                type: str
-                required: false
-              json:
-                include: any_map_or_list_with_ext_function
-              qos:
-                type: int
-                required: false
-          mqtt_response:
-            type: map
-            required: false
-            mapping:
-              topic:
-                type: str
-                required: true
-              payload:
-                type: any
-                required: false
-              json:
-                include: any_map_or_list_with_ext_function
-              timeout:
-                type: float
-                required: false
-              qos:
-                type: int
-                required: false
-                enum:
-                  - 0
-                  - 1
-                  - 2
-
-          request:
-            type: map
-            required: false
-            mapping:
-              url:
-                type: str
-                required: true
-
-              re;(params|headers):
-                include: any_map_with_ext_function
-
-              data:
-                type: any
-                func: validate_data_key_with_ext_function
-                required: false
-
-              stream:
-                type: bool
-                required: false
-
-              auth:
-                func: validate_extensions
-                type: seq
-                required: false
-                sequence:
-                  - type: str
-                    required: true
-                  - type: str
-                    required: true
-
-              json:
-                include: any_map_or_list_with_ext_function
-
-              files:
-                required: false
-                type: map
-                mapping:
-                  re;(.*):
-                    type: str
-
-              method:
-                type: str
-                enum:
-                  - GET
-                  - PUT
-                  - POST
-                  - DELETE
-                  - PATCH
-                  - OPTIONS
-                  - HEAD
-
-              verify:
-                type: bool
-                required: false
-
-              meta:
-                type: seq
-                required: false
-                sequence:
-                  - type: str
-                    unique: true
-
-          response:
-            type: map
-            required: false
-            mapping:
-              strict:
-                func: check_strict_key
-                type: any
-
-              status_code:
-                type: any
-                func: validate_status_code_is_int_or_list_of_ints
-
-              cookies:
-                type: seq
-                required: false
-                sequence:
-                  - type: str
-                    unique: true
-
-              re;(headers|redirect_query_params):
-                include: any_map_with_ext_function
-
-              body:
-                include: any_map_or_list_with_ext_function
-
-              save:
-                include: any_map_with_ext_function
-                mapping:
-                  re;(\$ext|body|headers|redirect_query_params):
-                    type: any
+      - include: stage
+      - include: stage_ref

--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -296,7 +296,14 @@ class YamlItem(pytest.Item):
 
     @property
     def obj(self):
-        stages = ["{:d}: {:s}".format(i + 1, stage["name"]) for i, stage in enumerate(self.spec["stages"])]
+        stages = []
+        for i, stage in enumerate(self.spec["stages"]):
+            name = "<unknown>"
+            if "name" in stage:
+                name = stage["name"]
+            elif "id" in stage:
+                name = stage["id"]
+            stages.append("{:d}: {:s}".format(i + 1, name))
 
         # This needs to be a function or skipif breaks
         def fakefun():

--- a/tavern/util/exceptions.py
+++ b/tavern/util/exceptions.py
@@ -83,3 +83,10 @@ class InvalidExtFunctionError(TavernException):
 
 class JMESError(TavernException):
     """Error in JMES matching"""
+
+
+class InvalidStageReferenceError(TavernException):
+    """Error loading stage reference"""
+
+class DuplicateStageDefinitionError(TavernException):
+    """Stage with the specified ID previously defined"""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,6 +19,23 @@ def fix_example_includes():
             "http": "requests",
         },
         "strict": True,
+        "stages": [{
+            "id": "my_external_stage",
+            "name": "My external stage",
+            "request": {
+                "url": "http://www.bing.com",
+                "method": "GET",
+            },
+            "response": {
+                "status_code": 200,
+                "body": {
+                    "key": "value",
+                },
+                "headers": {
+                    "content-type": "application/json",
+                }
+            }
+        }]
     }
 
     return includes.copy()

--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,pypy,pypy3}-{generic,cookies,mqtt,advanced}
+envlist = {py27,py34,py35,py36,pypy,pypy3}-{generic,cookies,mqtt,advanced,components}
 skip_missing_interpreters = true
 
 [testenv]
@@ -11,6 +11,7 @@ changedir =
     mqtt: example/mqtt
     cookies: example/cookies
     advanced: example/advanced
+    components: example/components
     generic: tests/integration
 deps =
     docker-compose
@@ -33,6 +34,11 @@ commands =
 
     advanced: tavern-ci --stdout test_server.tavern.yaml --no-cov
     advanced: python -c "from tavern.core import run; run('test_server.tavern.yaml', pytest_args=['--no-cov'])"
+
+	components: tavern-ci --stdout test_ping.tavern.yaml --no-cov
+	components: tavern-ci --stdout test_hello.tavern.yaml --no-cov
+	components: python -c "from tavern.core import run; run('test_ping.tavern.yaml', pytest_args=['--no-cov'])"
+	components: python -c "from tavern.core import run; run('test_hello.tavern.yaml', pytest_args=['--no-cov'])"
 
     mqtt: tavern-ci --stdout test_mqtt.tavern.yaml --no-cov
     mqtt: python -c "from tavern.core import run; run('test_mqtt.tavern.yaml', pytest_args=['--no-cov'])"


### PR DESCRIPTION
Extend the includes to support definition of stages. Stages can simply
be defined in an include file just as they are defined as part of the
test spec. The schema for stages is extended to support an "id".
Included stages will define an id, which is then used to reference when
defining tests.

For example, an include file can now define resuable stages like this:
```
  stages:
    - id: login_as_user_foo
      request: ...
      response: ...
    - id: query_data
      request: ...
      response: ...
```
The "stages" part of a test spec has been extended to support stage
references. Stage reference results in the stage being copied into the
test spec as if it was defined there.

Test spec is extended to reference included stages
```
  includes:
    - !include common/stages.yaml
  test_name: Get data as user foo
  stages:
    - type: ref
      id: login_as_user_foo
    - name: Query data
      request: ...
      response: ...
```
All saved variables by referenced stages are available to subsequent
stages. So in the above example, credentials saved by
'login_as_user_foo' can be used in the rest of the test.