### PR TITLE
Adding str method to ReprdError class

### DIFF
--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -624,3 +624,15 @@ class ReprdError(object):
         tw.line("")
 
         self._print_errors(tw)
+
+    @property
+    def longreprtext(self):
+        import py
+        tw = py.io.TerminalWriter(stringio=True)
+        tw.hasmarkup = False
+        self.toterminal(tw)
+        exc = tw.stringio.getvalue()
+        return exc.strip()
+
+    def __str__(self):
+        return self.longreprtext

--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -1,4 +1,5 @@
 import re
+import py
 import io
 import logging
 import itertools
@@ -627,8 +628,7 @@ class ReprdError(object):
 
     @property
     def longreprtext(self):
-        import py
-        tw = py.io.TerminalWriter(stringio=True)
+        tw = io.TerminalWriter(stringio=True)
         tw.hasmarkup = False
         self.toterminal(tw)
         exc = tw.stringio.getvalue()

--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -1,9 +1,9 @@
 import re
-import py
 import io
 import logging
 import itertools
 import copy
+import py
 
 import attr
 from _pytest._code.code import FormattedExcinfo
@@ -628,7 +628,7 @@ class ReprdError(object):
 
     @property
     def longreprtext(self):
-        tw = py.io.TerminalWriter(stringio=True)
+        tw = py.io.TerminalWriter(stringio=True)  #pylint: disable=no-member
         tw.hasmarkup = False
         self.toterminal(tw)
         exc = tw.stringio.getvalue()

--- a/tavern/testutils/pytesthook.py
+++ b/tavern/testutils/pytesthook.py
@@ -628,7 +628,7 @@ class ReprdError(object):
 
     @property
     def longreprtext(self):
-        tw = io.TerminalWriter(stringio=True)
+        tw = py.io.TerminalWriter(stringio=True)
         tw.hasmarkup = False
         self.toterminal(tw)
         exc = tw.stringio.getvalue()


### PR DESCRIPTION
With the current tavern-beta-new-traceback implementation, it will not work with junitxml report. In order to fix that I added the str method which pytest reads to output to stdout. This fixes the junit xml report.