### PR TITLE
Use `install_requires` for the pytest-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,11 @@ class DeployPypi(Command):
             [args],
             msg="Uploading package to pypi")
 
-
 SETUP_REQUIRES = [
-    "setuptools>=36",
+    "setuptools>=36",    
+]
+
+INSTALL_REQUIRES = [
     "pytest-runner",
 ]
 
@@ -73,9 +75,8 @@ TESTS_REQUIRE = [
 
 setup(
     name="tavern",
-
     setup_requires=SETUP_REQUIRES,
-
+    install_requires=INSTALL_REQUIRES,
     cmdclass={
         "docs": BuildDocs,
         "upload_twine": DeployPypi,

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ SETUP_REQUIRES = [
 
 INSTALL_REQUIRES = [
     "pytest-runner",
+    "pyyaml"
 ]
 
 


### PR DESCRIPTION
Possible fix for #163 

edit: @michaelboulton I'm really confused as to how this was working at all given that it's now complaining about all these other dependencies being missing?