### PR TITLE
Support timeouts

### DIFF
--- a/example/simple/server.py
+++ b/example/simple/server.py
@@ -1,5 +1,6 @@
 from flask import Flask, jsonify, request
 
+import time
 
 app = Flask(__name__)
 
@@ -7,6 +8,8 @@ app = Flask(__name__)
 @app.route("/double", methods=["POST"])
 def double_number():
     r = request.get_json()
+
+    time.sleep(10)
 
     try:
         number = r["number"]

--- a/example/simple/server.py
+++ b/example/simple/server.py
@@ -9,7 +9,7 @@ app = Flask(__name__)
 def double_number():
     r = request.get_json()
 
-    time.sleep(10)
+    time.sleep(0.5)
 
     try:
         number = r["number"]

--- a/example/simple/test_server.tavern.yaml
+++ b/example/simple/test_server.tavern.yaml
@@ -11,7 +11,7 @@ stages:
       method: POST
       headers:
         content-type: application/json
-      timeout: 1
+      timeout: 0.25
     response:
       status_code: 200
       body:

--- a/example/simple/test_server.tavern.yaml
+++ b/example/simple/test_server.tavern.yaml
@@ -11,6 +11,7 @@ stages:
       method: POST
       headers:
         content-type: application/json
+      timeout: 1
     response:
       status_code: 200
       body:

--- a/tavern/response/base.py
+++ b/tavern/response/base.py
@@ -6,6 +6,7 @@ import warnings
 from tavern.util import exceptions
 from tavern.util.python_2_util import indent
 from tavern.util.dict_util import format_keys, check_keys_match_recursive
+from tavern.util.exceptions import TestFailError
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,10 @@ class BaseResponse(object):
         else:
             logger.error(msg, *args)
         self.errors += [(msg % args)]
+
+    def _raise_if_failed(self):
+        if self.errors:
+            raise TestFailError("Test '{:s}' failed:\n{:s}".format(self.name, self._str_errors()), failures=self.errors)
 
     @abstractmethod
     def verify(self, response):

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -228,6 +228,14 @@ mapping:
                   - type: str
                     unique: true
 
+              timeout:
+                type: float
+                required: false
+
+              allow_redirects:
+                type: bool
+                required: false
+
           response:
             type: map
             required: false


### PR DESCRIPTION
@michaelboulton I've started looking at adding timeout support from #164 (thought I'd also expose a couple of other requests features too).

A problem I've hit at the moment is what we should do in order to capture and produce error messages when a plugin's `run` method does not perform as expected - e.g. it raises rather than completes. Currently the error message is just `E   RestRequestException` and a stack trace, however I think we need to be able to take errors and turn them in to more friendly output.

In the case of the timeout I was looking to be able to take the test definition to extract the timeout value used, (although I should be able to get this from the request too), and I was looking to be able to call the `_adderr` method in order to print out a friendly error message.

Conceptually it's nicer to group this with the response logic, but in terms of passing stuff around it doesn't feel nice that `request.run` can return a `Response` or `Exception` type now (though I guess that varies by plugin anyway).

I've committed a working example, which temporarily forks the simple example. Keen to know what you think about the approach and then I'll tidy it up.