### PR TITLE
Update import to fix deprecation warning

### DIFF
--- a/tavern/response/base.py
+++ b/tavern/response/base.py
@@ -1,5 +1,5 @@
 import logging
-import collections
+from collections import Mapping
 from abc import abstractmethod
 import warnings
 
@@ -66,7 +66,7 @@ class BaseResponse(object):
                 expected_block, blockname, blockname)
             return
 
-        if isinstance(block, collections.Mapping):
+        if isinstance(block, Mapping):
             block = dict(block)
 
         logger.debug("expected = %s, actual = %s", expected_block, block)


### PR DESCRIPTION
This PR is to fix pytest deprecation warnings such as:

```
.../site-packages/tavern/response/base.py:69: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  if isinstance(block, collections.Mapping):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

