### PR TITLE
Fix CI Deploy 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ stages:
   - name: full-tests
     if: branch = master OR type = pull_request OR tag IS present
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present
 
 sudo: required
 dist: xenial


### PR DESCRIPTION
Closes #169 I think.

AFAICT The travis file has a condition on the branch being master. On a tag, the branch will be the tag name so the deploy stage would never fire.

See https://travis-ci.org/bitdivision/tavern I cancelled the build, but the deploy stage started.