### PR TITLE
Issue #308

### DIFF
--- a/tavern/testutils/pytesthook/error.py
+++ b/tavern/testutils/pytesthook/error.py
@@ -176,8 +176,8 @@ class ReprdError(object):
             """Get lines between start and end mark"""
             with io.open(filename, "r", encoding="utf8") as testfile:
                 for idx, line in enumerate(testfile.readlines()):
-                    if first_line < idx < last_line and not line.lstrip().startswith("#"):
-                        yield line.rstrip()
+                    if first_line < idx < last_line:
+                        yield line.split("#", 1)[0].rstrip()
 
         code_lines = list(read_relevant_lines(self.item.spec.start_mark.name))
 

--- a/tavern/testutils/pytesthook/error.py
+++ b/tavern/testutils/pytesthook/error.py
@@ -52,7 +52,8 @@ class ReprdError(object):
             """
             for line in lines:
                 for match in re.finditer(r"(.*?:\s+!raw)?(?(1).*|.*?(?P<format_var>(?<!{){[^{]*?}))", line):
-                    yield match.group("format_var")
+                    if match.group("format_var") is not None:
+                        yield match.group("format_var")
 
         format_variables = list(read_formatted_vars(code_lines))
 

--- a/tavern/testutils/pytesthook/error.py
+++ b/tavern/testutils/pytesthook/error.py
@@ -51,7 +51,9 @@ class ReprdError(object):
             """Go over all lines and try to find format variables
             """
             for line in lines:
-                for match in re.finditer(r"(.*?:\s+!raw)?(?(1).*|.*?(?P<format_var>(?<!{){[^{]*?}))", line):
+                for match in re.finditer(
+                    r"(.*?:\s+!raw)?(?(1).*|.*?(?P<format_var>(?<!{){[^{]*?}))", line
+                ):
                     if match.group("format_var") is not None:
                         yield match.group("format_var")
 

--- a/tavern/testutils/pytesthook/error.py
+++ b/tavern/testutils/pytesthook/error.py
@@ -49,11 +49,9 @@ class ReprdError(object):
 
         def read_formatted_vars(lines):
             """Go over all lines and try to find format variables
-
-            This might be a bit wonky if escaped curly braces are used...
             """
             for line in lines:
-                for match in re.finditer(r"(?P<format_var>{.*?})", line):
+                for match in re.finditer(r"(?<!{)(?P<format_var>{[^{]*?})", line):
                     yield match.group("format_var")
 
         format_variables = list(read_formatted_vars(code_lines))

--- a/tavern/testutils/pytesthook/error.py
+++ b/tavern/testutils/pytesthook/error.py
@@ -51,7 +51,7 @@ class ReprdError(object):
             """Go over all lines and try to find format variables
             """
             for line in lines:
-                for match in re.finditer(r"(?<!{)(?P<format_var>{[^{]*?})", line):
+                for match in re.finditer(r"(.*?:\s+!raw)?(?(1).*|.*?(?P<format_var>(?<!{){[^{]*?}))", line):
                     yield match.group("format_var")
 
         format_variables = list(read_formatted_vars(code_lines))

--- a/tavern/testutils/pytesthook/error.py
+++ b/tavern/testutils/pytesthook/error.py
@@ -176,7 +176,7 @@ class ReprdError(object):
             """Get lines between start and end mark"""
             with io.open(filename, "r", encoding="utf8") as testfile:
                 for idx, line in enumerate(testfile.readlines()):
-                    if first_line < idx < last_line:
+                    if first_line < idx < last_line and not line.lstrip().startswith("#"):
                         yield line.rstrip()
 
         code_lines = list(read_relevant_lines(self.item.spec.start_mark.name))


### PR DESCRIPTION
When we read the line, strip any comments from the end.
Regex: 
* Only look for variables in lines that don't have `!raw`
* Only match variables encapsulated by a single curly bracket pair.
i.e: match `{var}` and not `{{var}}`
