### PR TITLE
Make advanced example work outside UTC

### DIFF
--- a/docs/source/server.md
+++ b/docs/source/server.md
@@ -54,7 +54,7 @@ def login():
 
     payload = {
         "sub": "test-user",
-        "exp": datetime.datetime.now() + datetime.timedelta(hours=1)
+        "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=1)
     }
 
     token = jwt.encode(payload, SECRET, algorithm="HS256").decode("utf8")

--- a/example/advanced/server.py
+++ b/example/advanced/server.py
@@ -46,7 +46,7 @@ def login():
     payload = {
         "sub": "test-user",
         "aud": SERVERNAME,
-        "exp": datetime.datetime.now() + datetime.timedelta(hours=1),
+        "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=1),
     }
 
     token = jwt.encode(payload, SECRET, algorithm="HS256").decode("utf8")

--- a/example/components/server.py
+++ b/example/components/server.py
@@ -23,7 +23,7 @@ def login():
     payload = {
         "sub": "test-user",
         "aud": SERVERNAME,
-        "exp": datetime.datetime.now() + datetime.timedelta(hours=1),
+        "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=1),
     }
 
     token = jwt.encode(payload, SECRET, algorithm="HS256").decode("utf8")


### PR DESCRIPTION
The example server for the multi-stage test example was signing the
token in the local timezone. jwt.decode expects UTC, so if the local
time was offset from that, jwt.ExpiredSignatureError was raised.