### PR TITLE
Allow sending data and files in a single request

### DIFF
--- a/tavern/_plugins/rest/request.py
+++ b/tavern/_plugins/rest/request.py
@@ -78,11 +78,12 @@ def get_request_args(rspec, test_block_config):
         # Explicitly raise an error here
         # From requests docs:
         # Note, the json parameter is ignored if either data or files is passed.
-        raise exceptions.BadSchemaError(
-            "Can only specify one type of request data in HTTP request (tried to send {})".format(
-                " and ".join(in_request)
+        # However, we allow the data + files case, as requests handles it correctly
+        if set(in_request) != {"data", "files"}:
+            raise exceptions.BadSchemaError(
+                "Can only specify one type of request data in HTTP request (tried to "
+                "send {})".format(" and ".join(in_request))
             )
-        )
 
     headers = rspec.get("headers", {})
     has_content_header = "content-type" in [h.lower() for h in headers.keys()]

--- a/tests/integration/server.py
+++ b/tests/integration/server.py
@@ -115,6 +115,37 @@ def upload_fake_file():
     return '', 200
 
 
+@app.route("/fake_upload_file_data", methods=["POST"])
+def upload_fake_file_and_data():
+    if not request.files:
+        return "", 401
+
+    if not request.form.to_dict():
+        return "", 402
+
+    # Verify that the content type is `multipart`
+    if not request.content_type.startswith("multipart/form-data"):
+        return "", 403
+
+    if not mimetypes.inited:
+        mimetypes.init()
+
+    for key, item in request.files.items():
+        if item.filename:
+            filetype = ".{}".format(item.filename.split(".")[-1])
+            if filetype in mimetypes.suffix_map:
+                if not item.content_type:
+                    return "", 400
+
+    # Try to download each of the files downloaded to /tmp
+    for key in request.files:
+        file_to_save = request.files[key]
+        path = os.path.join("/tmp", file_to_save.filename)
+        file_to_save.save(path)
+
+    return "", 200
+
+
 @app.route("/nested/again", methods=["GET"])
 def multiple_path_items_response():
     response = {

--- a/tests/integration/test_files.tavern.yaml
+++ b/tests/integration/test_files.tavern.yaml
@@ -18,6 +18,25 @@ stages:
 
 ---
 
+test_name: Test files can be uploaded alongside data
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: Upload file and data
+    request:
+      url: "{host}/fake_upload_file_data"
+      method: POST
+      files:
+        test_files: "test_files.tavern.yaml"
+      data:
+        key: value
+    response:
+      status_code: 200
+
+---
+
 test_name: Test extra headers don't break content-type
 
 includes:

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -145,12 +145,19 @@ class TestRequestArgs(object):
 
         assert args["data"]["array"] == ["def456", "def456"]
 
-    def test_file_and_data_fails(self, req, includes):
-        """Can't send json/form data and files at once"""
+    def test_file_and_json_fails(self, req, includes):
+        """Can't send json and files at once"""
         req["files"] = ["abc"]
+        req["json"] = {"key": "value"}
 
         with pytest.raises(exceptions.BadSchemaError):
             get_request_args(req, includes)
+
+    def test_file_and_data_succeeds(self, req, includes):
+        """Can send form data and files at once"""
+        req["files"] = ["abc"]
+
+        get_request_args(req, includes)
 
     @pytest.mark.parametrize("extra_headers", ({}, {"x-cool-header": "plark"}))
     def test_headers_no_content_type_change(self, req, includes, extra_headers):


### PR DESCRIPTION
Requests handles this case correctly, so I don't see any reason for tavern to forbid it. And I find it to be a very normal use case for the library, as APIs often include endpoints of this form. In particular, image uploads alongside form text data are fairly typical in my experience.

This fixes https://github.com/taverntesting/tavern/issues/382.