### PR TITLE
Fix minor inconsistency in doc filenames

### DIFF
--- a/docs/source/basics.md
+++ b/docs/source/basics.md
@@ -1085,7 +1085,7 @@ Say we have a login stage that needs to be run before every test in our
 test suite. Stages are defined in a configuration file like this:
 
 ```yaml
-# stage_auth.yaml
+# auth_stage.yaml
 ---
 
 name: Authentication stage


### PR DESCRIPTION
The yaml filename to be included was called `stage_auth.yaml` but the
yaml file with tests tries to include a file called `auth_stage.yaml`