### PR TITLE
Change warning about structure of code being different to 'info'

### DIFF
--- a/tavern/util/dict_util.py
+++ b/tavern/util/dict_util.py
@@ -311,7 +311,7 @@ def check_keys_match_recursive(expected_val, actual_val, keys, strict=True):
                 if extra_expected_keys or strict:
                     raise_from(exceptions.KeyMismatchError(full_msg), e)
                 else:
-                    logger.warning(full_msg, exc_info=True)
+                    logger.info(full_msg, exc_info=True)
 
             # If strict is True, an error will be raised above. If not, recurse
             # through both sets of keys and just ignore missing ones


### PR DESCRIPTION
This _can_ be useful if the further checks fail, but having it be a warning has confused people in the past

closes https://github.com/taverntesting/tavern/issues/176