### PR TITLE
docker instructions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -8,3 +8,5 @@ commit = True
 
 [bumpversion:file:docs/source/conf.py]
 
+[bumpversion:file:docs/source/cookbook.md]
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,119 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+tags
+.pytest_cache
+
+.bumpversion.cfg
+.cache
+.coverage
+dist
+docker
+docs
+.eggs
+example
+.git
+.gitignore
+LICENSE
+# MANIFEST.in
+.pylintrc
+.pytest_cache
+README.rst
+requirements.txt
+# setup.cfg
+# setup.py
+tags
+# tavern
+tavern.egg-info
+tests
+.tox
+tox.ini
+tox-integration.ini
+.travis.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,8 @@ repos:
   hooks:
   - id: black
     language_version: python3.7
-- repo: https://github.com/PyCQA/prospector
-  rev: 1.1.6 # The version of Prospector to use, at least 1.1.6
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
   hooks:
-  - id: prospector
-    args:
-      - --strictness low
+  - id: pyflakes
+    language_version: python3.7

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-disable=missing-docstring,bad-continuation,fixme,invalid-name,line-too-long,too-few-public-methods,no-else-return,too-many-branches,locally-disabled,useless-object-inheritance
+disable=missing-docstring,bad-continuation,fixme,invalid-name,line-too-long,too-few-public-methods,no-else-return,too-many-branches,locally-disabled,useless-object-inheritance,no-else-raise
 ignore=tests
 
 [REPORTS]

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ jobs:
     - python: 2.7
       env: TOXENV=py27lint TOXCFG=tox.ini
       stage: basic-tests
-    - python: 3.6
-      env: TOXENV=py36lint TOXCFG=tox.ini
+    - python: 3.7
+      env: TOXENV=py37lint TOXCFG=tox.ini
       stage: basic-tests
 
     - python: 2.7

--- a/docs/source/cookbook.md
+++ b/docs/source/cookbook.md
@@ -15,6 +15,89 @@ to make test result reporting more pretty or less pretty.
 - `pytest-xdist` can be used to run your tests in parallel, speeding up
 test runs if you have a large number of tests
 
+## Using with docker
+
+Tavern can be fairly easily used with Docker to run your integration tests. Simply
+use this Dockerfile as a base and add any extra requirements you need (such as
+any Pytest plugins as mentioned above):
+
+```dockerfile
+# tavern.Dockerfile
+FROM python:3.7-alpine
+
+RUN pip3 install tavern
+```
+
+Build with:
+
+```shell script
+docker build --file tavern.Dockerfile --tag tavern:latest .
+```
+
+Or if you need a specific version (hopefully you shouldn't):
+
+```dockerfile
+# tavern.Dockerfile
+FROM python:3.7-alpine
+
+ARG TAVERNVER
+RUN pip3 install tavern==$TAVERNVER
+```
+
+```shell script
+export TAVERNVER=0.24.0
+docker build --build-arg TAVERNVER=$TAVERNVER --file tavern.Dockerfile --tag tavern:$TAVERNVER .
+```
+
+Note that if you do this in a folder with a lot of subfolders (for example, an
+npm project) you probably want to create a `.dockerignore` file so that the build
+does not take an incredibly long time to start up - see the documentation
+[here](https://docs.docker.com/engine/reference/builder/#dockerignore-file)
+for information on how to create one.
+
+This can be used by running it on the command line with `docker run`, but
+it is often easier to use it in a docker-compose file like this:
+
+```yaml
+---
+version: '3.4'
+
+services:
+  tavern:
+    build:
+      context: .
+      image: tavern.Dockerfile
+    env_file:
+      # Any extra environment variables for testing
+      # This will probably contain things like names of docker containers to run tests against
+      - required-env-keys.env
+    volumes:
+      # The folder that our integration tests are in
+      - ./integration_tests:/integration_tests
+      # If you have anything in your pytest configuration it will also need mounting
+      # here then pointing to with the -c flag to pytest
+    command:
+      - python
+      - -m
+      - pytest
+      # Point to any global configuration files
+      - --tavern-global-cfg
+      - /integration_tests/local_urls.yaml
+      # And any other flags you want to pass
+      - -p
+      - no:logging
+      # And then point to the folder we mounted above
+      - /integration_tests
+  
+  # Optionally also just run your application in a docker container as well
+  application:
+    build:
+      context: .
+      image: application.Dockerfile
+    command:
+      ...
+```
+
 ## Using marks with fixtures
 
 Though passing arguments into fixtures is unsupported at the time of writing,

--- a/smoke.bash
+++ b/smoke.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -ex
+
+PYVER=37
+
+tox -c tox.ini -e py${PYVER}flakes
+tox -c tox.ini -e py${PYVER}
+tox -c tox.ini -e py${PYVER}lint
+
+tox -c tox-integration.ini -e py${PYVER}-generic
+tox -c tox.ini -e py${PYVER}black

--- a/tavern/entry.py
+++ b/tavern/entry.py
@@ -1,14 +1,19 @@
 import argparse
 from argparse import ArgumentParser
 import logging.config
+from textwrap import dedent
 
 from .core import run
 
 
 class TavernArgParser(ArgumentParser):
     def __init__(self):
+        description = """Parse yaml + make requests against an API
+
+        Any extra arguments will be passed directly to Pytest. Run py.test --help for a list"""
+
         super(TavernArgParser, self).__init__(
-            description="""Parse yaml + make requests against an API""",
+            description=dedent(description),
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,pypy,pypy3,py27lint,py36lint
+envlist = py27,py34,py35,py36,py37,pypy,pypy3,py27lint,py37lint
 skip_missing_interpreters = true
 
 [testenv]
@@ -28,6 +28,7 @@ commands =
     ; prospector --tool mypy
 
 [testenv:py27flakes]
+skip_install=true
 basepython = python2.7
 deps =
     prospector
@@ -35,6 +36,7 @@ commands =
     prospector --tool pyflakes --test-warnings
 
 [testenv:py37flakes]
+skip_install=true
 basepython = python3.7
 deps =
     prospector


### PR DESCRIPTION
As the dockerfile is just one line I think it's better to just tell people how to make a Tavern dockerfile themselves and include it in the documentation rather than maintaining an extra dockerfile.

The real difficulty is in mounting the right volumes and pointing the correct configuration anyway, so there is an example of how to do that in the docs.

closes https://github.com/taverntesting/tavern/issues/48