### PR TITLE
Add hook which runs before every test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,9 @@ jobs:
     - python: 3.7
       env: TOXENV=py37-advanced TOXCFG=tox-integration.ini
       stage: full-tests
+    - python: 3.7
+      env: TOXENV=py37-hooks TOXCFG=tox-integration.ini
+      stage: full-tests
     - stage: deploy
       script: skip
       deploy:

--- a/docs/source/basics.md
+++ b/docs/source/basics.md
@@ -1949,7 +1949,11 @@ tests.
 
 These hooks are used by defining a function with the name of the hook in your
 `conftest.py` that take the same arguments _with the same names_ - these hooks
-will then be picked up at runtime and called appropriately
+will then be picked up at runtime and called appropriately.
+
+**NOTE**: These hooks should be considered a 'beta' feature, they are ready to
+use but the names and arguments they take should be considered unstable and may
+change in a future release (and more may also be added).
 
 ### Before every test run
 
@@ -1968,7 +1972,7 @@ Example usage:
 ```python
 import logging
 
-def pytest_tavern_before_every_test_run(test_dict, variables):
+def pytest_tavern_beta_before_every_test_run(test_dict, variables):
     logging.info("Starting test %s", test_dict["test_name"])
     
     variables["extra_var"] = "abc123"
@@ -1990,7 +1994,7 @@ Args:
 Example usage:
 
 ```python
-def pytest_tavern_after_every_response(expected, response):
+def pytest_tavern_beta_after_every_response(expected, response):
     with open("logfile.txt", "a") as logfile:
         logfile.write("Got response: {}".format(response.json()))
 ```

--- a/example/hooks/Dockerfile
+++ b/example/hooks/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.5-alpine
+
+RUN pip install flask pyjwt
+
+COPY server.py /
+
+ENV FLASK_APP=/server.py
+
+CMD ["flask", "run", "--host=0.0.0.0"]

--- a/example/hooks/conftest.py
+++ b/example/hooks/conftest.py
@@ -14,7 +14,7 @@ def setup_logging():
     logging.basicConfig(level=logging.INFO)
 
 
-def pytest_tavern_after_every_response(expected, response):
+def pytest_tavern_beta_after_every_response(expected, response):
     global name
     logging.debug(expected)
     logging.debug(response)

--- a/example/hooks/conftest.py
+++ b/example/hooks/conftest.py
@@ -1,8 +1,12 @@
+import os
+import tempfile
 import logging
 
 import pytest
 
 logger = logging.getLogger(__name__)
+
+name = None
 
 
 @pytest.fixture(autouse=True)
@@ -11,6 +15,28 @@ def setup_logging():
 
 
 def pytest_tavern_after_every_response(expected, response):
-    logging.critical(expected)
-    logging.critical(response)
-    assert 0
+    global name
+    logging.debug(expected)
+    logging.debug(response)
+    with open(name, "a") as tfile:
+        tfile.write("abc\n")
+
+
+@pytest.fixture(autouse=True)
+def after_check_result():
+    """Create a temporary file for the duration of the test, and make sure the above hook was called"""
+    global name
+    with tempfile.NamedTemporaryFile(delete=False) as tfile:
+        try:
+            tfile.close()
+
+            name = tfile.name
+            yield
+
+            with open(tfile.name, "r") as opened:
+                contents = opened.readlines()
+                assert len(contents) == 2
+                assert all(i.strip() == "abc" for i in contents)
+
+        finally:
+            os.remove(tfile.name)

--- a/example/hooks/conftest.py
+++ b/example/hooks/conftest.py
@@ -1,0 +1,16 @@
+import logging
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def setup_logging():
+    logging.basicConfig(level=logging.INFO)
+
+
+def pytest_tavern_after_every_response(expected, response):
+    logging.critical(expected)
+    logging.critical(response)
+    assert 0

--- a/example/hooks/docker-compose.yaml
+++ b/example/hooks/docker-compose.yaml
@@ -1,0 +1,10 @@
+---
+version: '2'
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "5000:5000"

--- a/example/hooks/server.py
+++ b/example/hooks/server.py
@@ -1,0 +1,21 @@
+from flask import Flask, jsonify, request
+
+
+app = Flask(__name__)
+
+
+@app.route("/double", methods=["POST"])
+def double_number():
+    r = request.get_json()
+
+    try:
+        number = r["number"]
+    except (KeyError, TypeError):
+        return jsonify({"error": "no number passed"}), 400
+
+    try:
+        double = int(number) * 2
+    except ValueError:
+        return jsonify({"error": "a number was not passed"}), 400
+
+    return jsonify({"double": double}), 200

--- a/example/hooks/test_server.tavern.yaml
+++ b/example/hooks/test_server.tavern.yaml
@@ -1,0 +1,94 @@
+---
+
+test_name: Make sure server doubles number properly
+
+stages:
+  - name: Make sure number is returned correctly
+    request:
+      url: http://localhost:5000/double
+      json:
+        number: 5
+      method: POST
+      headers:
+        content-type: application/json
+    response:
+      status_code: 200
+      body:
+        double: 10
+
+---
+
+test_name: Check invalid inputs are handled
+
+stages:
+  - name: Make sure invalid numbers don't cause an error
+    request:
+      url: http://localhost:5000/double
+      json:
+        number: dkfsd
+      method: POST
+      headers:
+        content-type: application/json
+    response:
+      status_code: 400
+      body:
+        error: a number was not passed
+
+  - name: Make sure it raises an error if a number isn't passed
+    request:
+      url: http://localhost:5000/double
+      json:
+        wrong_key: 5
+      method: POST
+      headers:
+        content-type: application/json
+    response:
+      status_code: 400
+      body:
+        error: no number passed
+
+---
+
+test_name: Make sure server doubles number properly in series
+
+stages:
+  - name: Double the initial number
+    request:
+      url: http://localhost:5000/double
+      json:
+        number: 5
+      method: POST
+      headers:
+        content-type: application/json
+    response:
+      status_code: 200
+      save:
+        body:
+          value: double
+
+  - name: Double the number again and save the result
+    request:
+      url: http://localhost:5000/double
+      json:
+        number: !int "{value:d}"
+      method: POST
+      headers:
+        content-type: application/json
+    response:
+      status_code: 200
+      save:
+        body:
+          doubled_value: double
+
+  - name: Make sure number is the same as before
+    request:
+      url: http://localhost:5000/double
+      json:
+        number: !int "{value:d}"
+      method: POST
+      headers:
+        content-type: application/json
+    response:
+      status_code: 200
+      body:
+        double: !int "{doubled_value:d}"

--- a/example/hooks/test_server.tavern.yaml
+++ b/example/hooks/test_server.tavern.yaml
@@ -16,79 +16,15 @@ stages:
       body:
         double: 10
 
----
-
-test_name: Check invalid inputs are handled
-
-stages:
-  - name: Make sure invalid numbers don't cause an error
+  - name: Make sure number is returned correctly again
     request:
       url: http://localhost:5000/double
       json:
-        number: dkfsd
-      method: POST
-      headers:
-        content-type: application/json
-    response:
-      status_code: 400
-      body:
-        error: a number was not passed
-
-  - name: Make sure it raises an error if a number isn't passed
-    request:
-      url: http://localhost:5000/double
-      json:
-        wrong_key: 5
-      method: POST
-      headers:
-        content-type: application/json
-    response:
-      status_code: 400
-      body:
-        error: no number passed
-
----
-
-test_name: Make sure server doubles number properly in series
-
-stages:
-  - name: Double the initial number
-    request:
-      url: http://localhost:5000/double
-      json:
-        number: 5
-      method: POST
-      headers:
-        content-type: application/json
-    response:
-      status_code: 200
-      save:
-        body:
-          value: double
-
-  - name: Double the number again and save the result
-    request:
-      url: http://localhost:5000/double
-      json:
-        number: !int "{value:d}"
-      method: POST
-      headers:
-        content-type: application/json
-    response:
-      status_code: 200
-      save:
-        body:
-          doubled_value: double
-
-  - name: Make sure number is the same as before
-    request:
-      url: http://localhost:5000/double
-      json:
-        number: !int "{value:d}"
+        number: 10
       method: POST
       headers:
         content-type: application/json
     response:
       status_code: 200
       body:
-        double: !int "{doubled_value:d}"
+        double: 20

--- a/tavern/_plugins/mqtt/response.py
+++ b/tavern/_plugins/mqtt/response.py
@@ -80,7 +80,7 @@ class MQTTResponse(BaseResponse):
 
             call_hook(
                 self.test_block_config,
-                "pytest_tavern_after_every_response",
+                "pytest_tavern_beta_after_every_response",
                 expected=self.expected,
                 response=msg,
             )

--- a/tavern/_plugins/rest/response.py
+++ b/tavern/_plugins/rest/response.py
@@ -152,7 +152,7 @@ class RestResponse(BaseResponse):
 
         call_hook(
             self.test_block_config,
-            "pytest_tavern_after_every_response",
+            "pytest_tavern_beta_after_every_response",
             expected=self.expected,
             response=response,
         )

--- a/tavern/_plugins/rest/response.py
+++ b/tavern/_plugins/rest/response.py
@@ -9,6 +9,7 @@ except ImportError:
 
 from requests.status_codes import _codes
 
+from tavern.testutils.pytesthook.newhooks import call_hook
 from tavern.schemas.extensions import get_wrapped_response_function
 from tavern.util.dict_util import recurse_access_key, deep_dict_merge
 from tavern.util import exceptions
@@ -148,6 +149,13 @@ class RestResponse(BaseResponse):
             TestFailError: Something went wrong with validating the response
         """
         self._verbose_log_response(response)
+
+        call_hook(
+            self.test_block_config,
+            "pytest_tavern_after_every_response",
+            expected=self.expected,
+            response=response,
+        )
 
         self.response = response
         self.status_code = response.status_code

--- a/tavern/testutils/pytesthook/__init__.py
+++ b/tavern/testutils/pytesthook/__init__.py
@@ -1,4 +1,9 @@
 from .hooks import pytest_collect_file, pytest_addoption, pytest_addhooks
 from .util import add_parser_options
 
-__all__ = ["pytest_addoption", "pytest_collect_file", "pytest_addhooks", "add_parser_options"]
+__all__ = [
+    "pytest_addoption",
+    "pytest_collect_file",
+    "pytest_addhooks",
+    "add_parser_options",
+]

--- a/tavern/testutils/pytesthook/__init__.py
+++ b/tavern/testutils/pytesthook/__init__.py
@@ -1,4 +1,4 @@
-from .hooks import pytest_collect_file, pytest_addoption
+from .hooks import pytest_collect_file, pytest_addoption, pytest_addhooks
 from .util import add_parser_options
 
-__all__ = ["pytest_addoption", "pytest_collect_file", "add_parser_options"]
+__all__ = ["pytest_addoption", "pytest_collect_file", "pytest_addhooks", "add_parser_options"]

--- a/tavern/testutils/pytesthook/hooks.py
+++ b/tavern/testutils/pytesthook/hooks.py
@@ -54,3 +54,10 @@ def pytest_collect_file(parent, path):
         return YamlFile(path, parent)
 
     return None
+
+
+def pytest_addhooks(pluginmanager):
+    """Add our custom tavern hooks"""
+    from . import newhooks
+
+    pluginmanager.add_hookspecs(newhooks)

--- a/tavern/testutils/pytesthook/item.py
+++ b/tavern/testutils/pytesthook/item.py
@@ -10,6 +10,7 @@ from tavern.core import run_test
 from tavern.plugins import load_plugins
 from tavern.schemas.files import verify_tests
 from tavern.util import exceptions
+from testutils.pytesthook.newhooks import call_hook
 
 from .error import ReprdError
 from .util import load_global_cfg
@@ -151,10 +152,11 @@ class YamlItem(pytest.Item):
             fixture_values = self._load_fixture_values()
             self.global_cfg["variables"].update(fixture_values)
 
-            self.global_cfg["tavern_internal"][
-                "pytest_hook_caller"
-            ].pytest_tavern_before_every_test_run(
-                test_dict=self.spec, variables=self.global_cfg["variables"]
+            call_hook(
+                self.global_cfg,
+                "pytest_tavern_before_every_test_run",
+                test_dict=self.spec,
+                variables=self.global_cfg["variables"],
             )
 
             verify_tests(self.spec)

--- a/tavern/testutils/pytesthook/item.py
+++ b/tavern/testutils/pytesthook/item.py
@@ -154,8 +154,7 @@ class YamlItem(pytest.Item):
             self.global_cfg["tavern_internal"][
                 "pytest_hook_caller"
             ].pytest_tavern_before_every_test_run(
-                test_dict=self.spec,
-                variables=self.global_cfg["variables"]
+                test_dict=self.spec, variables=self.global_cfg["variables"]
             )
 
             verify_tests(self.spec)

--- a/tavern/testutils/pytesthook/item.py
+++ b/tavern/testutils/pytesthook/item.py
@@ -139,6 +139,8 @@ class YamlItem(pytest.Item):
 
         load_plugins(self.global_cfg)
 
+        self.global_cfg["tavern_internal"] = {"pytest_hook_caller": self.config.hook}
+
         # INTERNAL
         # NOTE - now that we can 'mark' tests, we could use pytest.mark.xfail
         # instead. This doesn't differentiate between an error in verification
@@ -146,10 +148,17 @@ class YamlItem(pytest.Item):
         xfail = self.spec.get("_xfail", False)
 
         try:
-            verify_tests(self.spec)
-
             fixture_values = self._load_fixture_values()
             self.global_cfg["variables"].update(fixture_values)
+
+            self.global_cfg["tavern_internal"][
+                "pytest_hook_caller"
+            ].pytest_tavern_before_every_test_run(
+                test_dict=self.spec,
+                variables=self.global_cfg["variables"]
+            )
+
+            verify_tests(self.spec)
 
             run_test(self.path, self.spec, self.global_cfg)
         except exceptions.BadSchemaError:

--- a/tavern/testutils/pytesthook/item.py
+++ b/tavern/testutils/pytesthook/item.py
@@ -10,7 +10,7 @@ from tavern.core import run_test
 from tavern.plugins import load_plugins
 from tavern.schemas.files import verify_tests
 from tavern.util import exceptions
-from testutils.pytesthook.newhooks import call_hook
+from tavern.testutils.pytesthook.newhooks import call_hook
 
 from .error import ReprdError
 from .util import load_global_cfg

--- a/tavern/testutils/pytesthook/item.py
+++ b/tavern/testutils/pytesthook/item.py
@@ -154,7 +154,7 @@ class YamlItem(pytest.Item):
 
             call_hook(
                 self.global_cfg,
-                "pytest_tavern_before_every_test_run",
+                "pytest_tavern_beta_before_every_test_run",
                 test_dict=self.spec,
                 variables=self.global_cfg["variables"],
             )

--- a/tavern/testutils/pytesthook/newhooks.py
+++ b/tavern/testutils/pytesthook/newhooks.py
@@ -10,7 +10,6 @@ def pytest_tavern_before_every_test_run(test_dict, variables):
     - directly after fixtures are loaded for a test
     - directly before verifying the schema of the file
     - Before formatting is done on values
-    - After fixtures have been resolved
     - After global configuration has been loaded
     - After plugins have been loaded
 

--- a/tavern/testutils/pytesthook/newhooks.py
+++ b/tavern/testutils/pytesthook/newhooks.py
@@ -1,4 +1,7 @@
 # pylint: disable=unused-argument
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def pytest_tavern_before_every_test_run(test_dict, variables):
@@ -17,3 +20,20 @@ def pytest_tavern_before_every_test_run(test_dict, variables):
         test_dict (dict): Test to run
         variables (dict): Available variables
     """
+
+
+def call_hook(test_block_config, hookname, **kwargs):
+    """Utility to call the hooks"""
+    try:
+        hook = getattr(
+            test_block_config["tavern_internal"]["pytest_hook_caller"], hookname
+        )
+    except AttributeError:
+        logger.critical("Error getting tavern hook!")
+        raise
+
+    try:
+        hook(**kwargs)
+    except AttributeError:
+        logger.error("Error calling tavern hook!")
+        raise

--- a/tavern/testutils/pytesthook/newhooks.py
+++ b/tavern/testutils/pytesthook/newhooks.py
@@ -48,5 +48,5 @@ def call_hook(test_block_config, hookname, **kwargs):
     try:
         hook(**kwargs)
     except AttributeError:
-        logger.error("Error calling tavern hook!")
+        logger.error("Unexpected error calling tavern hook")
         raise

--- a/tavern/testutils/pytesthook/newhooks.py
+++ b/tavern/testutils/pytesthook/newhooks.py
@@ -4,7 +4,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def pytest_tavern_before_every_test_run(test_dict, variables):
+def pytest_tavern_beta_before_every_test_run(test_dict, variables):
     """Called:
 
     - directly after fixtures are loaded for a test
@@ -21,7 +21,7 @@ def pytest_tavern_before_every_test_run(test_dict, variables):
     """
 
 
-def pytest_tavern_after_every_response(expected, response):
+def pytest_tavern_beta_after_every_response(expected, response):
     """Called after every _response_ - including MQTT/HTTP/etc
 
     Note:

--- a/tavern/testutils/pytesthook/newhooks.py
+++ b/tavern/testutils/pytesthook/newhooks.py
@@ -1,0 +1,19 @@
+# pylint: disable=unused-argument
+
+
+def pytest_tavern_before_every_test_run(test_dict, variables):
+    """Called:
+
+    - directly after fixtures are loaded for a test
+    - directly before verifying the schema of the file
+    - Before formatting is done on values
+    - After fixtures have been resolved
+    - After global configuration has been loaded
+    - After plugins have been loaded
+
+    Modify the test in-place if you want to do something to it.
+
+    Args:
+        test_dict (dict): Test to run
+        variables (dict): Available variables
+    """

--- a/tavern/testutils/pytesthook/newhooks.py
+++ b/tavern/testutils/pytesthook/newhooks.py
@@ -22,6 +22,19 @@ def pytest_tavern_before_every_test_run(test_dict, variables):
     """
 
 
+def pytest_tavern_after_every_response(expected, response):
+    """Called after every _response_ - including MQTT/HTTP/etc
+
+    Note:
+        - The response object type and the expected dict depends on what plugin you're using, and which kind of response it is!
+        - MQTT responses will call this hook multiple times if multiple messages are received
+
+    Args:
+        response (object): Response object.
+        expected (dict): Response block in stage
+    """
+
+
 def call_hook(test_block_config, hookname, **kwargs):
     """Utility to call the hooks"""
     try:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+from mock import Mock
 import pytest
 
 
@@ -13,6 +14,7 @@ def fix_example_includes():
         },
         "backends": {"mqtt": "paho-mqtt", "http": "requests"},
         "strict": True,
+        "tavern_internal": {"pytest_hook_caller": Mock()},
     }
 
     return includes.copy()

--- a/tests/unit/response/test_mqtt_response.py
+++ b/tests/unit/response/test_mqtt_response.py
@@ -27,7 +27,7 @@ class FakeMessage:
 
 
 class TestResponse(object):
-    def _get_fake_verifier(self, expected, fake_messages):
+    def _get_fake_verifier(self, expected, fake_messages, includes):
         """Given a list of messages, return a mocked version of the MQTT
         response verifier which will take messages off the front of this list as
         if they were published
@@ -51,16 +51,16 @@ class TestResponse(object):
 
         fake_client = Mock(spec=MQTTClient, message_received=yield_all_messages())
 
-        return MQTTResponse(fake_client, "Test stage", expected, {})
+        return MQTTResponse(fake_client, "Test stage", expected, includes)
 
-    def test_message_on_same_topic_fails(self):
+    def test_message_on_same_topic_fails(self, includes):
         """Correct topic, wrong message"""
 
         expected = {"topic": "/a/b/c", "payload": "hello"}
 
         fake_message = FakeMessage({"topic": "/a/b/c", "payload": "goodbye"})
 
-        verifier = self._get_fake_verifier(expected, [fake_message])
+        verifier = self._get_fake_verifier(expected, [fake_message], includes)
 
         with pytest.raises(exceptions.TestFailError):
             verifier.verify(expected)
@@ -68,21 +68,21 @@ class TestResponse(object):
         assert len(verifier.received_messages) == 1
         assert verifier.received_messages[0].topic == fake_message.topic
 
-    def test_correct_message(self):
+    def test_correct_message(self, includes):
         """Both correct matches"""
 
         expected = {"topic": "/a/b/c", "payload": "hello"}
 
         fake_message = FakeMessage(expected)
 
-        verifier = self._get_fake_verifier(expected, [fake_message])
+        verifier = self._get_fake_verifier(expected, [fake_message], includes)
 
         verifier.verify(expected)
 
         assert len(verifier.received_messages) == 1
         assert verifier.received_messages[0].topic == fake_message.topic
 
-    def test_correct_message_eventually(self):
+    def test_correct_message_eventually(self, includes):
         """One wrong messge, then the correct one"""
 
         expected = {"topic": "/a/b/c", "payload": "hello"}
@@ -91,7 +91,7 @@ class TestResponse(object):
         fake_message_bad = FakeMessage({"topic": "/a/b/c", "payload": "goodbye"})
 
         verifier = self._get_fake_verifier(
-            expected, [fake_message_bad, fake_message_good]
+            expected, [fake_message_bad, fake_message_good], includes
         )
 
         verifier.verify(expected)

--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37,pypy,pypy3}-{generic,cookies,mqtt,advanced,components,noextra}
+envlist = {py27,py34,py35,py36,py37,pypy,pypy3}-{generic,cookies,mqtt,advanced,components,noextra,hooks}
 skip_missing_interpreters = true
 
 [testenv]
@@ -13,6 +13,7 @@ changedir =
     cookies: example/cookies
     advanced: example/advanced
     components: example/components
+    hooks: example/hooks
     generic: tests/integration
     noextra: tests/integration
 deps =
@@ -24,10 +25,10 @@ deps =
     paho-mqtt
     mqtt: fluent-logger
 commands =
-    docker-compose stop
+;    docker-compose stop
     docker-compose build
     docker-compose up -d
-    python -m pytest --tb=short --tavern-global-cfg={toxinidir}/tests/integration/global_cfg.yaml
+    python -m pytest --tb=short --tavern-global-cfg={toxinidir}/tests/integration/global_cfg.yaml --tavern-beta-new-traceback
 
     cookies: tavern-ci --stdout test_server.tavern.yaml
     cookies: python -c "from tavern.core import run; exit(run('test_server.tavern.yaml', pytest_args=[]))"


### PR DESCRIPTION
There will be more hooks added to do more stuff in future but this one should provide at least some kind of a base to build the other ones on (see https://github.com/taverntesting/tavern/pull/177)

This just adds a hook which is called before every test (As according to the docstring) with the test block itself and any available variables.

Fixtures are meant for getting variables to use in the test, or to parametrize it, etc. Hooks provide more of an insight into the internals of Tavern to do things that are impossible with fixtures.

closes #113

relates to #177