### PR TITLE
cookie improvements

### DIFF
--- a/docs/source/http.md
+++ b/docs/source/http.md
@@ -178,6 +178,31 @@ stages:
         status: access denied
 ```
 
+#### Overriding cookies
+
+If you want to override the value of a cookie, then instead of passing a string
+to the `cookies` block in the request, use a mapping of `cookie name: cookie
+value`:
+
+```yaml
+  - name: Override cookie value
+    request:
+      url: "{host}/expect_cookie"
+      method: GET
+      cookies:
+        - tavern-cookie-2: abc
+    response:
+      status_code: 200
+      body:
+        status: ok
+
+```
+
+This will create a new cookie with the name `tavern-cookie-2` with the value
+`abc` and send it in the request. If this cookie already exists from a previous
+stage, it will be overwritten. Trying to override the cookie multiple times in
+one stage will cause an error to occur at runtime.
+
 ### HTTP Basic Auth
 
 For a server that expects HTTP Basic Auth, the `auth` keyword can be used in the

--- a/example/cookies/server.py
+++ b/example/cookies/server.py
@@ -1,9 +1,7 @@
-import sqlite3
-import datetime
 import functools
-from flask import Flask, jsonify, request, g, session
-import jwt
+import sqlite3
 
+from flask import Flask, jsonify, request, g, session
 
 app = Flask(__name__)
 app.secret_key = "t1uNraxw+9oxUyCuXHO2G0u38ig="

--- a/tavern/_plugins/rest/request.py
+++ b/tavern/_plugins/rest/request.py
@@ -234,9 +234,9 @@ def _read_expected_cookies(session, rspec, test_block_config):
     # Need to do this down here - it is separate from getting request args as
     # it depends on the state of the session
     existing_cookies = session.cookies.get_dict()
-    available_cookies = format_keys(rspec.get("cookies", []),
-                                    test_block_config["variables"],
-                                    )
+    available_cookies = format_keys(
+        rspec.get("cookies", []), test_block_config["variables"]
+    )
     missing = set(available_cookies) - set(existing_cookies.keys())
 
     if missing:

--- a/tavern/_plugins/rest/request.py
+++ b/tavern/_plugins/rest/request.py
@@ -234,7 +234,9 @@ def _read_expected_cookies(session, rspec, test_block_config):
     # Need to do this down here - it is separate from getting request args as
     # it depends on the state of the session
     existing_cookies = session.cookies.get_dict()
-    available_cookies = rspec.get("cookies", [])
+    available_cookies = format_keys(rspec.get("cookies", []),
+                                    test_block_config["variables"],
+                                    )
     missing = set(available_cookies) - set(existing_cookies.keys())
 
     if missing:
@@ -245,10 +247,7 @@ def _read_expected_cookies(session, rspec, test_block_config):
             )
         )
 
-    return format_keys(
-        {c: existing_cookies.get(c) for c in available_cookies},
-        test_block_config["variables"],
-    )
+    return {c: existing_cookies.get(c) for c in available_cookies}
 
 
 class RestRequest(BaseRequest):

--- a/tavern/_plugins/rest/request.py
+++ b/tavern/_plugins/rest/request.py
@@ -234,7 +234,7 @@ def _read_expected_cookies(session, rspec, test_block_config):
     # Need to do this down here - it is separate from getting request args as
     # it depends on the state of the session
     existing_cookies = session.cookies.get_dict()
-    available_cookies = rspec.get("cookies", {})
+    available_cookies = rspec.get("cookies", [])
     missing = set(available_cookies) - set(existing_cookies.keys())
 
     if missing:
@@ -299,7 +299,9 @@ class RestRequest(BaseRequest):
             request_args.update(cookies=expected_cookies)
 
         # Check for redirects
-        request_args.update(allow_redirects=_check_allow_redirects(rspec, test_block_config))
+        request_args.update(
+            allow_redirects=_check_allow_redirects(rspec, test_block_config)
+        )
 
         logger.debug("Request args: %s", request_args)
 

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -153,6 +153,10 @@ schema;stage:
           required: false
           sequence:
             - type: str
+            - type: map
+              mapping:
+                re;(.*):
+                  type: str
 
         json:
           include: any_json_with_ext

--- a/tavern/util/exceptions.py
+++ b/tavern/util/exceptions.py
@@ -107,3 +107,7 @@ class InvalidQueryResultTypeError(TavernException):
 
 class UnexpectedDocumentsError(TavernException):
     """Multiple documents were found in a YAML file when only one was expected"""
+
+
+class DuplicateCookieError(TavernException):
+    """User tried to reuse a cookie from a previous request and override it in the same request"""

--- a/tests/integration/common.yaml
+++ b/tests/integration/common.yaml
@@ -17,6 +17,8 @@ variables:
   verify_false: "False"
   delay_before_0_1: 0.1
 
+  formatted-cookie-name: tavern-cookie-2
+
 stages:
   - id: typetoken-anything-match
     name: match top level

--- a/tests/integration/test_cookies.tavern.yaml
+++ b/tests/integration/test_cookies.tavern.yaml
@@ -232,3 +232,99 @@ stages:
       status_code: 200
       body:
         status: ok
+
+---
+
+test_name: Trying to override the value of a cookie multiple times causes an error
+
+# TODO: Make this fail in verify instead?
+_xfail: run
+
+includes:
+  - !include common.yaml
+
+stages:
+  - *get-cookie-1
+
+  - name: Send a cookie which doesn't exist
+    request:
+      url: "{host}/expect_cookie"
+      method: GET
+      json:
+        cookie_name: tavern-cookie-2
+      cookies:
+        - cookie-1: abc
+        - cookie-1: abc
+    response:
+      status_code: 200
+      body:
+        status: ok
+
+---
+
+test_name: Override a cookie on the first stage
+
+includes:
+  - !include common.yaml
+
+stages:
+  - *get-cookie-1
+
+  - name: Send a cookie which doesn't exist
+    request:
+      url: "{host}/expect_cookie"
+      method: GET
+      json:
+        cookie_name: tavern-cookie-2
+      cookies:
+        - tavern-cookie-2: abc
+    response:
+      status_code: 200
+      body:
+        status: ok
+
+---
+
+test_name: Override a cookie on the first stage
+
+includes:
+  - !include common.yaml
+
+stages:
+  - *get-cookie-1
+
+  - name: Override cookie value
+    request:
+      url: "{host}/expect_cookie"
+      method: GET
+      json:
+        cookie_name: tavern-cookie-2
+      cookies:
+        - tavern-cookie-2: abc
+    response:
+      status_code: 200
+      body:
+        status: ok
+
+---
+
+test_name: Override a cookie on the first stage, with formatting
+
+includes:
+  - !include common.yaml
+
+stages:
+  - *get-cookie-1
+
+  - name: Override cookie value
+    request:
+      url: "{host}/expect_cookie"
+      method: GET
+      json:
+        cookie_name: "{formatted-cookie-name}"
+      cookies:
+        - tavern-cookie-2: abc
+    response:
+      status_code: 200
+      body:
+        status: ok

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -156,6 +156,31 @@ class TestCookies(object):
 
         assert _read_expected_cookies(mock_session, req, includes) == {"a": 2}
 
+    def test_no_overwrite_cookie(self, req, includes):
+        """cant redefine a cookie from previous request"""
+
+        cookiejar = RequestsCookieJar()
+        cookiejar.set("a", 2)
+
+        req["cookies"] = ["a", {"a": "sjidfsd"}]
+
+        mock_session = Mock(spec=requests.Session, cookies=cookiejar)
+
+        with pytest.raises(exceptions.DuplicateCookieError):
+            _read_expected_cookies(mock_session, req, includes)
+
+    def test_no_duplicate_cookie(self, req, includes):
+        """Can't override a cookiev alue twice"""
+
+        cookiejar = RequestsCookieJar()
+
+        req["cookies"] = [{"a": "sjidfsd"}, {"a": "fjhj"}]
+
+        mock_session = Mock(spec=requests.Session, cookies=cookiejar)
+
+        with pytest.raises(exceptions.DuplicateCookieError):
+            _read_expected_cookies(mock_session, req, includes)
+
 
 class TestRequestArgs(object):
     def test_default_method(self, req, includes):

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -127,6 +127,19 @@ class TestCookies(object):
 
         assert _read_expected_cookies(mock_session, req, includes) == {"a": 2}
 
+    def test_format_cookies(self, req, includes):
+        """cookies in request should be formatted"""
+
+        cookiejar = RequestsCookieJar()
+        cookiejar.set("a", 2)
+
+        req["cookies"] = ["{cookiename}"]
+        includes["variables"]["cookiename"] = "a"
+
+        mock_session = Mock(spec=requests.Session, cookies=cookiejar)
+
+        assert _read_expected_cookies(mock_session, req, includes) == {"a": 2}
+
 
 class TestRequestArgs(object):
     def test_default_method(self, req, includes):

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -105,6 +105,17 @@ class TestCookies(object):
         cookiejar.set("a", 2)
         mock_session = Mock(spec=requests.Session, cookies=cookiejar)
 
+        assert _read_expected_cookies(mock_session, req, includes) == None
+
+    def test_ask_for_nothing(self, req, includes):
+        """explicitly ask fo rno cookies"""
+
+        cookiejar = RequestsCookieJar()
+        cookiejar.set("a", 2)
+        mock_session = Mock(spec=requests.Session, cookies=cookiejar)
+
+        req["cookies"] = []
+
         assert _read_expected_cookies(mock_session, req, includes) == {}
 
     def test_not_available_but_wanted(self, mock_session, req, includes):


### PR DESCRIPTION
In the case that the name of a cookie may be included ina  variable, or an external config file, but only one cookie should be sent in a request

closes #418