### PR TITLE
Satisfy pytest warning for failed regex match in helpers

### DIFF
--- a/tavern/testutils/helpers.py
+++ b/tavern/testutils/helpers.py
@@ -116,7 +116,7 @@ def validate_regex(response, expression, header=None):
     else:
         content = response.text
 
-    match = re.search(expression, content)
+    match = re.search(expression, content) or False
     assert match
 
     return {"regex": Box(match.groupdict())}


### PR DESCRIPTION
Variable becomes False instead of None when there is no match

This addresses warnings produced by pytest when the match fails, which can become excessive if there's lots of tests or lots of retries

```
 PytestAssertRewriteWarning: asserting the value None, please use "assert is None"
```