### PR TITLE
1.0/strict changes

### DIFF
--- a/tavern/_plugins/mqtt/response.py
+++ b/tavern/_plugins/mqtt/response.py
@@ -58,6 +58,9 @@ class MQTTResponse(BaseResponse):
         topic = self.expected["topic"]
         timeout = self.expected.get("timeout", 1)
 
+        test_strictness = self.test_block_config["strict"]
+        block_strictness = test_strictness.setting_for("json").is_on()
+
         expected_payload, expect_json_payload = self._get_payload_vals()
 
         # Any warnings to do with the request
@@ -121,7 +124,9 @@ class MQTTResponse(BaseResponse):
             elif msg.payload != expected_payload:
                 if expect_json_payload:
                     try:
-                        check_keys_match_recursive(expected_payload, msg.payload, [])
+                        check_keys_match_recursive(
+                            expected_payload, msg.payload, [], strict=block_strictness
+                        )
                     except exceptions.KeyMismatchError:
                         # Just want to log the mismatch
                         pass

--- a/tavern/_plugins/rest/response.py
+++ b/tavern/_plugins/rest/response.py
@@ -221,5 +221,5 @@ class RestResponse(BaseResponse):
         logger.debug("Validating response %s against %s", blockname, expected_block)
 
         test_strictness = self.test_block_config["strict"]
-        block_strictness = test_strictness.setting_for(blockname)
+        block_strictness = test_strictness.setting_for(blockname).is_on()
         self.recurse_check_key_match(expected_block, block, blockname, block_strictness)

--- a/tavern/_plugins/rest/response.py
+++ b/tavern/_plugins/rest/response.py
@@ -220,12 +220,6 @@ class RestResponse(BaseResponse):
 
         logger.debug("Validating response %s against %s", blockname, expected_block)
 
-        # 'strict' could be a list, in which case we only want to enable strict
-        # key checking for that specific bit of the response
         test_strictness = self.test_block_config["strict"]
-        if isinstance(test_strictness, list):
-            block_strictness = blockname in test_strictness
-        else:
-            block_strictness = test_strictness
-
+        block_strictness = test_strictness.setting_for(blockname)
         self.recurse_check_key_match(expected_block, block, blockname, block_strictness)

--- a/tavern/core.py
+++ b/tavern/core.py
@@ -203,9 +203,16 @@ def _calculate_stage_strictness(stage, test_block_config, test_spec):
     elif stage.get("mqtt_response", {}).get("strict", None) is not None:
         stage_options = stage["mqtt_response"]["strict"]
 
-    if stage_options:
+    if stage_options is not None:
         logger.debug("Overriding global strictness")
-        test_block_config["strict"] = StrictLevel.from_options(stage_options)
+        if stage_options is True:
+            strict_level = StrictLevel.all_on()
+        elif stage_options is False:
+            strict_level = StrictLevel.all_off()
+        else:
+            strict_level = StrictLevel.from_options(stage_options)
+
+        test_block_config["strict"] = strict_level
     else:
         logger.debug("Global default strictness used for this stage")
 

--- a/tavern/response/base.py
+++ b/tavern/response/base.py
@@ -87,7 +87,7 @@ class BaseResponse(object):
         try:
             check_keys_match_recursive(expected_block, block, [], strict)
         except exceptions.KeyMismatchError as e:
-            self._adderr("Key mismatch", e=e)
+            self._adderr(e.args[0], e=e)
 
     def _check_for_validate_functions(self, response_block):
         """

--- a/tavern/schemas/extensions.py
+++ b/tavern/schemas/extensions.py
@@ -9,6 +9,7 @@ from pykwalify.types import is_bool, is_float, is_int
 from tavern.util import exceptions
 from tavern.util.exceptions import BadSchemaError
 from tavern.util.loader import ApproxScalar, BoolToken, FloatToken, IntToken
+from tavern.util.strict_util import StrictLevel
 
 
 def _getlogger():
@@ -371,8 +372,8 @@ def check_strict_key(value, rule_obj, path):
     if not isinstance(value, list) and not is_bool_like(value):
         raise BadSchemaError("'strict' has to be either a boolean or a list")
     elif isinstance(value, list):
-        if not {"json", "headers", "redirect_query_params"} >= set(value):
-            raise BadSchemaError("Invalid 'strict' keys passed: {}".format(value))
+        # Reuse validation here
+        StrictLevel.from_options(value)
 
     return True
 

--- a/tavern/schemas/extensions.py
+++ b/tavern/schemas/extensions.py
@@ -378,6 +378,8 @@ def check_strict_key(value, rule_obj, path):
         except exceptions.InvalidConfigurationException as e:
             raise BadSchemaError from e
 
+    # Might be a bool as well, in which case it's processed further down the line - no validation required
+
     return True
 
 

--- a/tavern/schemas/extensions.py
+++ b/tavern/schemas/extensions.py
@@ -372,8 +372,11 @@ def check_strict_key(value, rule_obj, path):
     if not isinstance(value, list) and not is_bool_like(value):
         raise BadSchemaError("'strict' has to be either a boolean or a list")
     elif isinstance(value, list):
-        # Reuse validation here
-        StrictLevel.from_options(value)
+        try:
+            # Reuse validation here
+            StrictLevel.from_options(value)
+        except exceptions.InvalidConfigurationException as e:
+            raise BadSchemaError from e
 
     return True
 

--- a/tavern/testutils/pytesthook/item.py
+++ b/tavern/testutils/pytesthook/item.py
@@ -171,10 +171,8 @@ class YamlItem(pytest.Item):
     def repr_failure(self, excinfo):
         """ called when self.runtest() raises an exception.
 
-        Todo:
-            This stuff is copied from pytest at the moment - needs a bit of
-            modifying so that it shows the yaml and all the reasons the test
-            failed rather than a traceback
+        By default, will raise a custom formatted traceback if it's a tavern error. if not, will use the default
+        python traceback
         """
 
         if (

--- a/tavern/testutils/pytesthook/item.py
+++ b/tavern/testutils/pytesthook/item.py
@@ -181,9 +181,9 @@ class YamlItem(pytest.Item):
             or not issubclass(excinfo.type, exceptions.TavernException)
             or issubclass(excinfo.type, exceptions.BadSchemaError)
         ):
-            return ReprdError(excinfo, self)
+            return super(YamlItem, self).repr_failure(excinfo)
 
-        return super(YamlItem, self).repr_failure(excinfo)
+        return ReprdError(excinfo, self)
 
     def reportinfo(self):
         return self.fspath, 0, "{s.path}::{s.name:s}".format(s=self)

--- a/tavern/testutils/pytesthook/util.py
+++ b/tavern/testutils/pytesthook/util.py
@@ -3,9 +3,9 @@ import os
 
 from box import Box
 
-from tavern.util import exceptions
 from tavern.util.dict_util import format_keys
 from tavern.util.general import load_global_config
+from tavern.util.strict_util import StrictLevel
 
 try:
     from functools import lru_cache
@@ -122,17 +122,9 @@ def _load_global_backends(pytest_config):
 def _load_global_strictness(pytest_config):
     """Load the global 'strictness' setting"""
 
-    strict = get_option_generic(pytest_config, "tavern-strict", [])
+    options = get_option_generic(pytest_config, "tavern-strict", [])
 
-    if isinstance(strict, list):
-        valid_keys = ["json", "headers", "redirect_query_params"]
-        if any(i not in valid_keys for i in strict):
-            msg = "Invalid values for 'strict' given - expected one of {}, got {}".format(
-                valid_keys, strict
-            )
-            raise exceptions.InvalidConfigurationException(msg)
-
-    return strict
+    return StrictLevel.from_options(options)
 
 
 def _load_global_follow_redirects(pytest_config):

--- a/tavern/util/retry.py
+++ b/tavern/util/retry.py
@@ -18,31 +18,17 @@ def retry(stage, test_block_config):
     max_retries = stage.get("max_retries", 0)
 
     if max_retries == 0:
-        # Just catch exceptions
         def catch_wrapper(fn):
             @wraps(fn)
             def wrapped(*args, **kwargs):
-                try:
-                    res = fn(*args, **kwargs)
-                except exceptions.TestFailError:
-                    raise
-                except exceptions.BadSchemaError:
-                    raise
-                except exceptions.TavernException as e:
-                    raise exceptions.TestFailError(
-                        "Test '{}' failed: stage did not succeed in {} retries.".format(
-                            stage["name"], max_retries
-                        )
-                    ) from e
-                else:
-                    logger.debug("Stage '%s' succeeded.", stage["name"])
-                    return res
+                res = fn(*args, **kwargs)
+                logger.debug("Stage '%s' succeeded.", stage["name"])
+                return res
 
             return wrapped
 
         return catch_wrapper
     else:
-
         def retry_wrapper(fn):
             @wraps(fn)
             def wrapped(*args, **kwargs):

--- a/tavern/util/retry.py
+++ b/tavern/util/retry.py
@@ -24,6 +24,8 @@ def retry(stage, test_block_config):
             def wrapped(*args, **kwargs):
                 try:
                     res = fn(*args, **kwargs)
+                except exceptions.TestFailError:
+                    raise
                 except exceptions.BadSchemaError:
                     raise
                 except exceptions.TavernException as e:
@@ -65,12 +67,15 @@ def retry(stage, test_block_config):
                                 stage["name"],
                                 max_retries,
                             )
-                            raise exceptions.TestFailError(
-                                "Test '{}' failed: stage did not succeed in {} retries.".format(
-                                    stage["name"], max_retries
-                                )
-                            ) from e
 
+                            if isinstance(e, exceptions.TestFailError):
+                                raise
+                            else:
+                                raise exceptions.TestFailError(
+                                    "Test '{}' failed: stage did not succeed in {} retries.".format(
+                                        stage["name"], max_retries
+                                    )
+                                ) from e
                     else:
                         break
 

--- a/tavern/util/retry.py
+++ b/tavern/util/retry.py
@@ -18,6 +18,7 @@ def retry(stage, test_block_config):
     max_retries = stage.get("max_retries", 0)
 
     if max_retries == 0:
+
         def catch_wrapper(fn):
             @wraps(fn)
             def wrapped(*args, **kwargs):
@@ -29,6 +30,7 @@ def retry(stage, test_block_config):
 
         return catch_wrapper
     else:
+
         def retry_wrapper(fn):
             @wraps(fn)
             def wrapped(*args, **kwargs):

--- a/tavern/util/strict_util.py
+++ b/tavern/util/strict_util.py
@@ -51,7 +51,7 @@ def validate_and_parse_option(key):
     if not match:
         raise exceptions.InvalidConfigurationException(
             "Invalid value for 'strict' given - expected one of {}, got '{}'".format(
-                valid_keys, key
+                ["{}[:on/off]".format(key) for key in valid_keys], key
             )
         )
 

--- a/tavern/util/strict_util.py
+++ b/tavern/util/strict_util.py
@@ -1,0 +1,67 @@
+from distutils.util import strtobool
+import enum
+import re
+
+from tavern.util import exceptions
+
+
+class _StrictSetting(enum.Enum):
+    ON = 1
+    OFF = 2
+    UNSET = 3
+
+
+valid_keys = ["json", "headers", "redirect_query_params"]
+
+
+def _setting_factory(setting):
+    """Converts from cmdlin/setting file to an enum"""
+    if setting is None:
+        return _StrictSetting.UNSET
+    else:
+        parsed = strtobool(setting)
+
+        if parsed:
+            return _StrictSetting.ON
+        else:
+            return _StrictSetting.OFF
+
+
+class _StrictOption:
+    def __init__(self, section, setting):
+        self.section = section
+        self.setting = _setting_factory(setting)
+
+    def is_on(self):
+        if self.section == "json":
+            # Must be specifically disabled for response body
+            return self.setting != _StrictSetting.OFF
+        else:
+            # Off by default for everything else
+            return self.setting == _StrictSetting.ON
+
+
+def validate_and_parse_option(key):
+    regex = r"(?P<section>{})(:(?P<setting>on|off))?".format("|".join(valid_keys))
+
+    match = re.fullmatch(regex, key)
+
+    if not match:
+        raise exceptions.InvalidConfigurationException(
+            "Invalid value for 'strict' given - expected one of {}, got '{}'".format(
+                valid_keys, key
+            )
+        )
+
+    return _StrictOption(**match.groupdict())
+
+
+class StrictLevel:
+    def __init__(self, option):
+        if isinstance(option, str):
+            option = [option]
+
+        self.matched = [validate_and_parse_option(key) for key in option]
+
+    def setting_for(self, setting):
+        return self.matched[setting]

--- a/tavern/util/strict_util.py
+++ b/tavern/util/strict_util.py
@@ -71,6 +71,8 @@ class StrictLevel:
     def from_options(cls, options):
         if isinstance(options, str):
             options = [options]
+        elif not isinstance(options, list):
+            raise exceptions.InvalidConfigurationException("'strict' setting should be a bool or a list")
 
         parsed = [validate_and_parse_option(key) for key in options]
 
@@ -89,4 +91,4 @@ class StrictLevel:
     def all_on(cls):
         """Only used for unit tests
         """
-        return cls([i + ":on" for i in valid_keys])
+        return cls.from_options([i + ":on" for i in valid_keys])

--- a/tavern/util/strict_util.py
+++ b/tavern/util/strict_util.py
@@ -84,3 +84,9 @@ class StrictLevel:
             raise exceptions.InvalidConfigurationException(
                 "No setting for '{}'".format(section)
             ) from e
+
+    @classmethod
+    def all_on(cls):
+        """Only used for unit tests
+        """
+        return cls([i + ":on" for i in valid_keys])

--- a/tavern/util/strict_util.py
+++ b/tavern/util/strict_util.py
@@ -72,7 +72,9 @@ class StrictLevel:
         if isinstance(options, str):
             options = [options]
         elif not isinstance(options, list):
-            raise exceptions.InvalidConfigurationException("'strict' setting should be a bool or a list")
+            raise exceptions.InvalidConfigurationException(
+                "'strict' setting should be a list of strings"
+            )
 
         parsed = [validate_and_parse_option(key) for key in options]
 
@@ -89,6 +91,8 @@ class StrictLevel:
 
     @classmethod
     def all_on(cls):
-        """Only used for unit tests
-        """
         return cls.from_options([i + ":on" for i in valid_keys])
+
+    @classmethod
+    def all_off(cls):
+        return cls.from_options([i + ":off" for i in valid_keys])

--- a/tests/integration/common.yaml
+++ b/tests/integration/common.yaml
@@ -27,5 +27,4 @@ stages:
       method: GET
     response:
       status_code: 200
-      json:
-        top: !anything
+      json: !anything

--- a/tests/integration/test_jmes.tavern.yaml
+++ b/tests/integration/test_jmes.tavern.yaml
@@ -12,8 +12,6 @@ stages:
       method: GET
     response:
       status_code: 200
-      json:
-        an_integer: 123
       verify_response_with:
         function: tavern.testutils.helpers:validate_content
         extra_kwargs:

--- a/tests/integration/test_strict_key_checks.tavern.yaml
+++ b/tests/integration/test_strict_key_checks.tavern.yaml
@@ -297,6 +297,8 @@ test_name: Test non-strict key matching one list item
 strict:
   - json
 
+_xfail: run
+
 includes:
   - !include common.yaml
 
@@ -309,24 +311,24 @@ stages:
       strict: false
       json:
         - a
-
-  - name: match a middle item in the list
-    request:
-      url: "{host}/fake_list"
-    response:
-      status_code: 200
-      strict: false
-      json:
-        - c
-
-  - name: match a number in the middle of the list
-    request:
-      url: "{host}/fake_list"
-    response:
-      status_code: 200
-      strict: false
-      json:
-        - 2
+#
+#  - name: match a middle item in the list
+#    request:
+#      url: "{host}/fake_list"
+#    response:
+#      status_code: 200
+#      strict: false
+#      json:
+#        - c
+#
+#  - name: match a number in the middle of the list
+#    request:
+#      url: "{host}/fake_list"
+#    response:
+#      status_code: 200
+#      strict: false
+#      json:
+#        - 2
 
 ---
 

--- a/tests/integration/test_strict_key_checks.tavern.yaml
+++ b/tests/integration/test_strict_key_checks.tavern.yaml
@@ -162,6 +162,7 @@ test_name: Test strict key matching against headers with mismatch body passes
 
 strict:
   - headers
+  - json:off
 
 includes:
   - !include common.yaml
@@ -242,6 +243,9 @@ test_name: Test strict key matching works for specific test stages
 includes:
   - !include common.yaml
 
+strict:
+  - json:off
+
 stages:
   - name: match with one key missing
     request:
@@ -297,8 +301,6 @@ test_name: Test non-strict key matching one list item
 strict:
   - json
 
-_xfail: run
-
 includes:
   - !include common.yaml
 
@@ -311,24 +313,26 @@ stages:
       strict: false
       json:
         - a
-#
-#  - name: match a middle item in the list
-#    request:
-#      url: "{host}/fake_list"
-#    response:
-#      status_code: 200
-#      strict: false
-#      json:
-#        - c
-#
-#  - name: match a number in the middle of the list
-#    request:
-#      url: "{host}/fake_list"
-#    response:
-#      status_code: 200
-#      strict: false
-#      json:
-#        - 2
+
+  - name: match a middle item in the list
+    request:
+      url: "{host}/fake_list"
+    response:
+      status_code: 200
+#      Use new syntax
+      strict:
+        - json:off
+      json:
+        - c
+
+  - name: match a number in the middle of the list
+    request:
+      url: "{host}/fake_list"
+    response:
+      status_code: 200
+      strict: false
+      json:
+        - 2
 
 ---
 

--- a/tests/integration/test_typetokens.tavern.yaml
+++ b/tests/integration/test_typetokens.tavern.yaml
@@ -21,8 +21,7 @@ stages:
       method: GET
     response:
       status_code: 200
-      json:
-        top: !anything
+      json: !anything
 ---
 
 test_name: Test 'anything' token will match any response, from included stage
@@ -37,6 +36,9 @@ stages:
 ---
 
 test_name: Test bool type match
+
+strict:
+  - json:off
 
 includes:
   - !include common.yaml
@@ -63,6 +65,9 @@ stages:
 ---
 
 test_name: Test integer type match
+
+strict:
+  - json:off
 
 includes:
   - !include common.yaml
@@ -122,6 +127,9 @@ stages:
 
 test_name: Test string type match
 
+strict:
+  - json:off
+
 includes:
   - !include common.yaml
 
@@ -164,6 +172,7 @@ stages:
           nested: !anything
         an_integer: !anyint
         a_string: !anystr
+        a_bool: !anybool
 
 ---
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,8 @@
 from mock import Mock
 import pytest
 
+from tavern.util.strict_util import StrictLevel
+
 
 @pytest.fixture(name="includes")
 def fix_example_includes():
@@ -13,7 +15,7 @@ def fix_example_includes():
             "request_topic": "/abc",
         },
         "backends": {"mqtt": "paho-mqtt", "http": "requests"},
-        "strict": True,
+        "strict": StrictLevel.all_on(),
         "tavern_internal": {"pytest_hook_caller": Mock()},
     }
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -336,7 +336,7 @@ class TestTavernMetaFormat:
             "a_format_key": "{tavern.env_vars.%s}" % env_key
         }
 
-        with pytest.raises(exceptions.TestFailError):
+        with pytest.raises(exceptions.MissingFormatError):
             run_test("heif", fulltest, includes)
 
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -17,7 +17,11 @@ from tavern.testutils.pytesthook.item import YamlItem
 from tavern.util import exceptions
 from tavern.util.dict_util import _check_and_format_values, format_keys
 from tavern.util.loader import ForceIncludeToken
-from tavern.util.strict_util import validate_and_parse_option, StrictLevel, _StrictSetting
+from tavern.util.strict_util import (
+    validate_and_parse_option,
+    StrictLevel,
+    _StrictSetting,
+)
 
 
 class FakeResponse:

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -119,32 +119,24 @@ class TestTavernRepr:
         return excinfo
 
     def test_not_called_for_normal_exception(self, fake_item):
-        """Should now call tavern repr by default"""
+        """Does not call tavern repr for non tavern errors"""
         fake_info = self._make_fake_exc_info(RuntimeError)
 
         with patch("tavern.testutils.pytesthook.item.ReprdError") as rmock:
             fake_item.repr_failure(fake_info)
 
-        assert rmock.called
+        assert not rmock.called
 
-    def test_called_by_default(self, fake_item):
-        """called by default for tavern exceptions"""
+    @pytest.mark.parametrize("ini_flag", [True, False])
+    def test_not_called_for_badschema_tavern_exception_(self, fake_item, ini_flag):
+        """Does not call taven repr for badschemerror - tavern repr gives no useful information in this case"""
         fake_info = self._make_fake_exc_info(exceptions.BadSchemaError)
 
-        with patch("tavern.testutils.pytesthook.item.ReprdError") as rmock:
-            fake_item.repr_failure(fake_info)
-
-        assert rmock.called
-
-    def test_not_called_for_badschema_tavern_exception_(self, fake_item):
-        """Enable ini flag, should call old style exception, even with badschema"""
-        fake_info = self._make_fake_exc_info(exceptions.BadSchemaError)
-
-        with patch.object(fake_item.config, "getini", return_value=True):
+        with patch.object(fake_item.config, "getini", return_value=ini_flag):
             with patch("tavern.testutils.pytesthook.item.ReprdError") as rmock:
                 fake_item.repr_failure(fake_info)
 
-        assert rmock.called
+        assert not rmock.called
 
     def test_not_called_ini(self, fake_item):
         """Enable ini flag, should call old style"""
@@ -154,7 +146,7 @@ class TestTavernRepr:
             with patch("tavern.testutils.pytesthook.item.ReprdError") as rmock:
                 fake_item.repr_failure(fake_info)
 
-        assert rmock.called
+        assert not rmock.called
 
     def test_not_called_cli(self, fake_item):
         """Enable cli flag, should call old style"""
@@ -164,7 +156,7 @@ class TestTavernRepr:
             with patch("tavern.testutils.pytesthook.item.ReprdError") as rmock:
                 fake_item.repr_failure(fake_info)
 
-        assert rmock.called
+        assert not rmock.called
 
 
 @pytest.fixture(name="nested_response")


### PR DESCRIPTION
closes #489 

Changes strict settings to be a bit different

- can specify each one (headers, query params, json) be on or off individually
- json is on by default, others are off by default