### PR TITLE
fix: encoding="utf-8" when open text file

### DIFF
--- a/tavern/_plugins/mqtt/client.py
+++ b/tavern/_plugins/mqtt/client.py
@@ -58,7 +58,7 @@ def _handle_tls_args(tls_args):
 
     def check_file_exists(key):
         try:
-            with open(tls_args[key], "r"):
+            with open(tls_args[key], "r", encoding="utf-8"):
                 pass
         except IOError as e:
             raise exceptions.MQTTTLSError(

--- a/tavern/_plugins/mqtt/tavernhook.py
+++ b/tavern/_plugins/mqtt/tavernhook.py
@@ -37,5 +37,5 @@ verifier_type = MQTTResponse
 response_block_name = "mqtt_response"
 
 schema_path = join(abspath(dirname(__file__)), "schema.yaml")
-with open(schema_path, "r") as schema_file:
+with open(schema_path, "r", encoding="utf-8") as schema_file:
     schema = yaml.load(schema_file, Loader=yaml.SafeLoader)

--- a/tavern/util/loader.py
+++ b/tavern/util/loader.py
@@ -404,7 +404,7 @@ def load_single_document_yaml(filename):
         UnexpectedDocumentsError: If more than one document was in the file
     """
 
-    with open(filename, "r") as fileobj:
+    with open(filename, "r", encoding="utf-8") as fileobj:
         try:
             contents = yaml.load(fileobj, Loader=IncludeLoader)
         except yaml.composer.ComposerError as e:

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -413,6 +413,20 @@ class TestLoadCfg:
             finally:
                 os.remove(wrapped_tmp.name)
 
+    @pytest.mark.parametrize("value", ("b", "三木"))
+    def test_load_utf8(self, value):
+        """if yaml has utf8 char , may load error"""
+        content = f"""a: {value}""" ""
+
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            f.write(content.encode("utf8"))
+
+        try:
+            load_single_document_yaml(f.name)
+
+        finally:
+            os.remove(f.name)
+
 
 class TestLoadFile:
     @staticmethod


### PR DESCRIPTION
fix #586 

we add a testcase `tests.unit.test_utilities.TestLoadCfg.test_load_utf8`，
and 'encoding' parameter is added to all 'open' function that reads the text content