### PR TITLE
stop fixture request from raising a warning

### DIFF
--- a/tavern/testutils/pytesthook/item.py
+++ b/tavern/testutils/pytesthook/item.py
@@ -1,9 +1,9 @@
 import copy
 import logging
 
-from _pytest import fixtures
 import attr
 import pytest
+from pytest import FixtureRequest
 
 from tavern.core import run_test
 from tavern.plugins import load_plugins
@@ -54,7 +54,7 @@ class YamlItem(pytest.Item):
         )
         self._fixtureinfo = fixtureinfo
         self.fixturenames = fixtureinfo.names_closure
-        self._request = fixtures.FixtureRequest(self)
+        self._request = FixtureRequest(self, _ispytest=True)
 
     #     Hack to stop issue with pytest-rerunfailures
     _initrequest = initialise_fixture_attrs

--- a/tavern/testutils/pytesthook/item.py
+++ b/tavern/testutils/pytesthook/item.py
@@ -3,7 +3,6 @@ import logging
 
 import attr
 import pytest
-from pytest import FixtureRequest
 
 from tavern.core import run_test
 from tavern.plugins import load_plugins
@@ -54,7 +53,7 @@ class YamlItem(pytest.Item):
         )
         self._fixtureinfo = fixtureinfo
         self.fixturenames = fixtureinfo.names_closure
-        self._request = FixtureRequest(self, _ispytest=True)
+        self._request = pytest.FixtureRequest(self, _ispytest=True)
 
     #     Hack to stop issue with pytest-rerunfailures
     _initrequest = initialise_fixture_attrs


### PR DESCRIPTION
closes #655

Using the 'public' fixture request as noted in https://github.com/pytest-dev/pytest/issues/7469 , but this still raises the warning, so also pass _is_pytest=true