### PR TITLE
Upgrade pyKwalify from 1.7.0 to 1.8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ include_package_data = True
 
 install_requires =
     PyYAML>=5.3.1,<6
-    pykwalify>=1.7.0,<1.8
+    pykwalify>=1.8.0,<2
     requests>=2.22.0,<3
     pyjwt>=1.7.1,<2
     paho-mqtt>=1.3.1,<=1.5.1

--- a/tavern/schemas/files.py
+++ b/tavern/schemas/files.py
@@ -13,7 +13,7 @@ from tavern.plugins import load_plugins
 from tavern.util.exceptions import BadSchemaError
 from tavern.util.loader import IncludeLoader, load_single_document_yaml
 
-core.yaml.safe_load = functools.partial(yaml.load, Loader=IncludeLoader)
+core.yml.safe_load = functools.partial(yaml.load, Loader=IncludeLoader)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- apply [korvalds' patch](https://github.com/taverntesting/tavern/issues/631#issuecomment-756102624)
- remove annoying `DeprecationWarning` ([see also](https://github.com/taverntesting/tavern/issues/631#issuecomment-845123959))