### PR TITLE
remove restore-keys from tox cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,9 +70,6 @@ jobs:
       with:
         path: .tox
         key: ${{ runner.os }}-tox-${{ env.cache-name }}-${{ hashFiles('tox.ini', 'tox-integration.ini', 'setup.cfg', 'setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-tox-${{ env.cache-name }}-
-          ${{ runner.os }}-tox-
 
     - uses: actions/cache@v2
       with:


### PR DESCRIPTION
This keeps matching old tox caches which don't work when dependencies get updated