### PR TITLE
Add a decorator to supress result log in extfunctions

### DIFF
--- a/tavern/util/extfunctions.py
+++ b/tavern/util/extfunctions.py
@@ -89,7 +89,11 @@ def get_wrapped_response_function(ext):
     @functools.wraps(func)
     def inner(response):
         result = func(response, *args, **kwargs)
-        _getlogger().info("Result of calling '%s': '%s'", func, result)
+        suppress_logs = getattr(func, 'suppress_extfunction_result_log', False)
+        if suppress_logs:
+            _getlogger().info("Called '%s'", func)
+        else:
+            _getlogger().info("Result of calling '%s': '%s'", func, result)
         return result
 
     inner.func = func
@@ -106,12 +110,29 @@ def get_wrapped_create_function(ext):
     @functools.wraps(func)
     def inner():
         result = func(*args, **kwargs)
-        _getlogger().info("Result of calling '%s': '%s'", func, result)
+        suppress_logs = getattr(func, 'suppress_extfunction_result_log', False)
+        if suppress_logs:
+            _getlogger().info("Called '%s'", func)
+        else:
+            _getlogger().info("Result of calling '%s': '%s'", func, result)
         return result
 
     inner.func = func
 
     return inner
+
+
+def suppress_external_function_result_log(func):
+    """
+    A decorator to use with external functions to suppress result log
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    wrapper.suppress_extfunction_result_log = True
+    return wrapper
 
 
 def update_from_ext(request_args, keys_to_check, test_block_config):


### PR DESCRIPTION
This change allows to suppress result log when external functions are returning sensitive information. 

Fixes: #725

We run tavern tests within CI/CD pipelines and external functions are used for various purposes such as generating request body, verifying response and generating request headers.

In some cases, we use external functions to generate `Bearer` tokens. These are sensitive information and we do NOT want them to be logged when running the tests in 3rd party CI/CD providers.

Hope this will be useful to reduce the chance of sensitive information leaking via logs.

Please advise if we need to add documentation or tests. And also where to add them as we couldn't see an obvious spot. 

Thank you