### PR TITLE
Bugfix error condition checking in run() example

### DIFF
--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -161,10 +161,11 @@ The Python library allows you to include Tavern tests in deploy scripts written 
 
 ```python
 from tavern.core import run
+from pytest import ExitCode
 
-success = run("test_server.tavern.yaml")
+exit_code = run("test_server.tavern.yaml")
 
-if not success:
+if exit_code != ExitCode.OK:
     print("Error running tests")
 ```
 


### PR DESCRIPTION
The result of `run()` is a [pytest ExitCode class](https://docs.pytest.org/en/latest/reference/exit-codes.html), an Enum subclass which evidently uses C-style conventions where success is indicated by 0, so a successful run in this example will evaluate to `False` in the conditional and incorrectly print the error. There are a few ways to fix it, but IMO the clearest is to use the Enum class directly.