### PR TITLE
Lock pyjwt to 1.7.1 in component example

### DIFF
--- a/example/components/Dockerfile
+++ b/example/components/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.9-alpine
 
-RUN pip install flask pyjwt
+RUN pip install flask
+
+RUN pip install pyjwt==1.7.1
 
 COPY server.py /
 


### PR DESCRIPTION
Later versions of PyJWT raise exceptions like `AttributeError: 'str' object has no attribute 'decode'`.   Locking to earlier version allows existing syntax in Tavern examples to work in containerized servers.