### PR TITLE
Allow bools in parameterized values

### DIFF
--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -295,11 +295,13 @@ mapping:
                 required: true
                 sequence:
                   - type: str
+                  - type: bool
                   - type: int
                   - type: float
                   - type: seq
                     sequence:
                       - type: str
+                      - type: bool                      
                       - type: int
                       - type: float
 


### PR DESCRIPTION
The following `marks` entity use to cause error because `vals` couldn't contain Bools (or lists with Bools in them)

```
  - parametrize:
      key:
        - use_this
      vals:
        - True
        - False
```
This didn't work either

```
  - parametrize:
      key:
        - use_this
        - use_that
      vals:
        - [True, True]
        - [True, False]
        - [False, False]
        - [False, True]      
```

This code change allows the above code to work.