### PR TITLE
Add simple way of running a function before/after stages

### DIFF
--- a/scripts/smoke.bash
+++ b/scripts/smoke.bash
@@ -5,7 +5,9 @@ set -ex
 PYVER=39
 
 tox -c tox.ini        \
-  -e py${PYVER}flakes \
+  -e py${PYVER}flakes
+
+tox -c tox.ini        \
   -e py${PYVER}       \
   -e py${PYVER}-pytest6       \
   -e py${PYVER}black  \

--- a/tavern/core.py
+++ b/tavern/core.py
@@ -269,10 +269,8 @@ def run_stage(sessions, stage, test_block_config):
     )
 
     response = r.run()
-    logger.debug("Stage done")
 
     provider.end_tinctures(response)
-    logger.debug("tinctures done")
 
     for v in verifiers:
         saved = v.verify(response)

--- a/tavern/core.py
+++ b/tavern/core.py
@@ -245,7 +245,6 @@ def run_stage(sessions, stage, test_block_config):
         test_block_config (dict): available variables for test
     """
     stage = copy.deepcopy(stage)
-    name = stage["name"]
 
     attach_stage_content(stage)
 

--- a/tavern/core.py
+++ b/tavern/core.py
@@ -259,8 +259,6 @@ def run_stage(sessions, stage, test_block_config):
 
     delay(stage, "before", test_block_config["variables"])
 
-    logger.info("Running stage : %s", name)
-
     provider = TinctureProvider(stage)
     provider.start_tinctures(stage)
 
@@ -271,8 +269,10 @@ def run_stage(sessions, stage, test_block_config):
     )
 
     response = r.run()
+    logger.debug("Stage done")
 
     provider.end_tinctures(response)
+    logger.debug("tinctures done")
 
     for v in verifiers:
         saved = v.verify(response)

--- a/tavern/plugins.py
+++ b/tavern/plugins.py
@@ -7,9 +7,9 @@ import logging
 
 import stevedore
 
-from tavern.util.dict_util import format_keys
-
+from .request import BaseRequest
 from .util import exceptions
+from .util.dict_util import format_keys
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +163,7 @@ def get_extra_sessions(test_spec, test_block_config):
     return sessions
 
 
-def get_request_type(stage, test_block_config, sessions):
+def get_request_type(stage, test_block_config, sessions) -> BaseRequest:
     """Get the request object for this stage
 
     there can only be one

--- a/tavern/request/base.py
+++ b/tavern/request/base.py
@@ -3,6 +3,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+from box import Box
+
 
 class BaseRequest(object):
     @property
@@ -20,3 +22,8 @@ class BaseRequest(object):
     @abstractmethod
     def run(self):
         """Run test"""
+
+    @property
+    @abstractmethod
+    def request_vars(self) -> Box:
+        """Get any extra variables used for this request"""

--- a/tavern/request/base.py
+++ b/tavern/request/base.py
@@ -1,15 +1,15 @@
 from abc import abstractmethod
 import logging
 
-logger = logging.getLogger(__name__)
-
 from box import Box
+
+logger = logging.getLogger(__name__)
 
 
 class BaseRequest(object):
     @property
     @abstractmethod
-    def request_vars(self):
+    def request_vars(self) -> Box:
         """
         Variables used in the request
 
@@ -22,8 +22,3 @@ class BaseRequest(object):
     @abstractmethod
     def run(self):
         """Run test"""
-
-    @property
-    @abstractmethod
-    def request_vars(self) -> Box:
-        """Get any extra variables used for this request"""

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -28,6 +28,11 @@ schema;stage:
   required: true
   func: verify_oneof_id_name
   mapping:
+
+    tinctures:
+      func: validate_extensions
+      type: any
+
     id:
       type: str
       required: false

--- a/tavern/testutils/helpers.py
+++ b/tavern/testutils/helpers.py
@@ -196,4 +196,4 @@ def time_request(_):
 def print_response(_, extra_print="affa"):
     logger.warning("STARTING:")
     r = yield
-    logger.warning("Request is %s (%s)", r, extra_print)
+    logger.warning("Response is %s (%s)", r, extra_print)

--- a/tavern/testutils/helpers.py
+++ b/tavern/testutils/helpers.py
@@ -2,6 +2,7 @@ import importlib
 import json
 import logging
 import re
+import time
 
 from box import Box
 import jmespath
@@ -183,3 +184,16 @@ def validate_content(response, comparisons):
                 )
             except AssertionError as e:
                 raise exceptions.JMESError("Error validating JMES") from e
+
+
+def time_request(_):
+    t0 = time.time()
+    yield
+    t1 = time.time()
+    logger.warning("Request took %s", t1 - t0)
+
+
+def print_response(_, extra_print="affa"):
+    logger.warning("STARTING:")
+    r = yield
+    logger.warning("Request is %s (%s)", r, extra_print)

--- a/tavern/util/tincture.py
+++ b/tavern/util/tincture.py
@@ -1,0 +1,54 @@
+import inspect
+
+from tavern.schemas.extensions import get_wrapped_response_function
+from tavern.util import exceptions
+
+
+class TinctureProvider:
+    def __init__(self, stage):
+        self._tinctures = TinctureProvider._accumulate_tincture_funcs(stage)
+        self._needs_response = None
+
+    @staticmethod
+    def _accumulate_tincture_funcs(stage):
+        """
+        Get tinctures from stage
+
+        Args:
+            stage (dict): Test stage
+        """
+        tinctures = stage.get("tinctures", None)
+
+        if isinstance(tinctures, list):
+            for vf in tinctures:
+                yield get_wrapped_response_function(vf)
+        elif isinstance(tinctures, dict):
+            yield get_wrapped_response_function(tinctures)
+        elif tinctures is not None:
+            raise exceptions.BadSchemaError("Badly formatted 'tinctures' block")
+
+    def start_tinctures(self, stage):
+        results = [t(stage) for t in self._tinctures]
+
+        self._needs_response = [r for r in results if inspect.isgenerator(r)]
+
+    def end_tinctures(self, response):
+        """
+        Send the response object to any tinctures that want it
+
+        Args:
+            response (object): The response from 'run' for the stage
+        """
+        if self._needs_response is None:
+            raise RuntimeError(
+                "should not be called before accumulating tinctures which need a response"
+            )
+
+        for n in self._needs_response:
+            n.send(None)
+            try:
+                n.send(response)
+            except StopIteration:
+                pass
+            else:
+                raise RuntimeError("Tincture had more than one yield")

--- a/tests/integration/test_fixtures.tavern.yaml
+++ b/tests/integration/test_fixtures.tavern.yaml
@@ -140,3 +140,30 @@ stages:
       status_code: 200
       json:
         value: "{autouse_thing_named}"
+
+---
+
+test_name: Test tincture
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: do something
+    tinctures:
+      - function: tavern.core:a_thing
+      - function: tavern.core:nothing
+      - function: tavern.core:nothing2
+      - function: tavern.core:nothing2
+        extra_kwargs:
+          extra_print: "fkjiofjgk"
+    request:
+      url: "{host}/echo"
+      method: POST
+#      json:
+#        value: "{str_fixture}"
+    response:
+      status_code: 200
+      json:
+        value: "{yield_str_fixture}"
+        f: gf

--- a/tests/integration/test_fixtures.tavern.yaml
+++ b/tests/integration/test_fixtures.tavern.yaml
@@ -148,20 +148,24 @@ test_name: Test tincture
 includes:
   - !include common.yaml
 
+marks:
+  - usefixtures:
+      - yielder
+      - str_fixture
+      - yield_str_fixture
+
 stages:
   - name: do something
     tinctures:
-      - function: tavern.core:a_thing
-      - function: tavern.core:nothing
-      - function: tavern.core:nothing2
-      - function: tavern.core:nothing2
+      - function: tavern.testutils.helpers:time_request
+      - function: tavern.testutils.helpers:print_response
         extra_kwargs:
-          extra_print: "fkjiofjgk"
+          extra_print: "blooble"
     request:
       url: "{host}/echo"
       method: POST
-#      json:
-#        value: "{str_fixture}"
+      json:
+        value: "{str_fixture}"
     response:
       status_code: 200
       json:

--- a/tests/integration/test_fixtures.tavern.yaml
+++ b/tests/integration/test_fixtures.tavern.yaml
@@ -140,34 +140,3 @@ stages:
       status_code: 200
       json:
         value: "{autouse_thing_named}"
-
----
-
-test_name: Test tincture
-
-includes:
-  - !include common.yaml
-
-marks:
-  - usefixtures:
-      - yielder
-      - str_fixture
-      - yield_str_fixture
-
-stages:
-  - name: do something
-    tinctures:
-      - function: tavern.testutils.helpers:time_request
-      - function: tavern.testutils.helpers:print_response
-        extra_kwargs:
-          extra_print: "blooble"
-    request:
-      url: "{host}/echo"
-      method: POST
-      json:
-        value: "{str_fixture}"
-    response:
-      status_code: 200
-      json:
-        value: "{yield_str_fixture}"
-        f: gf

--- a/tests/integration/test_tincture.tavern.yaml
+++ b/tests/integration/test_tincture.tavern.yaml
@@ -1,0 +1,29 @@
+---
+
+test_name: Test tincture
+
+includes:
+- !include common.yaml
+
+marks:
+- usefixtures:
+  - yielder
+  - str_fixture
+  - yield_str_fixture
+
+stages:
+- name: do something
+  tinctures:
+  - function: tavern.testutils.helpers:time_request
+  - function: tavern.testutils.helpers:print_response
+    extra_kwargs:
+      extra_print: "blooble"
+  request:
+    url: "{host}/echo"
+    method: POST
+    json:
+      value: "{str_fixture}"
+  response:
+    status_code: 200
+    json:
+      value: "{yield_str_fixture}"

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
 [testenv:py39lint]
 basepython = python3.9
 commands =
-    pylint tavern/ -j 4
+    pylint tavern/ -j 0
 
 [testenv:py39flakes]
 skip_install = true


### PR DESCRIPTION
#114

simple way of running things before/after each stage, optionally taking the response as a 'yield' argument

should also be changed to allow specifying it at the test level and the 'global' level in the same way that strictness is