### PR TITLE
Bump paho-mqtt version to 1.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyYAML>=5.3.1,<7
 pykwalify>=1.8.0,<2
 requests>=2.22.0,<3
 pyjwt>=1.7.1,<2
-paho-mqtt>=1.3.1,<=1.5.1
+paho-mqtt>=1.3.1,<=1.6.1
 jmespath<1
 pytest>=6.2,<8
 python-box>4,<6


### PR DESCRIPTION
This was artificially kept to an older version due to a bug in 1.6.0 that was affecting some people. All the tests are still passing with 1.6.1 and 1.5.1, so if anybody is still having issues they will need to manually pin to an older version