### PR TITLE
Allow specifying 'unexpected' messages in MQTT to fail a test

### DIFF
--- a/example/mqtt/test_mqtt_failures.tavern.yaml
+++ b/example/mqtt/test_mqtt_failures.tavern.yaml
@@ -92,3 +92,25 @@ stages:
       topic: /device/123/status/response
       timeout: 3
       qos: 1
+
+---
+
+test_name: Test unexpected message fails
+
+includes:
+- !include common.yaml
+
+paho-mqtt: *mqtt_spec
+
+_xfail: run
+
+stages:
+- name: step 1 - ping/pong
+  mqtt_publish:
+    topic: /devices/status
+  mqtt_response:
+    topic: /device/123/status/response
+    payload: !anything
+    timeout: 3
+    qos: 1
+    unexpected: true

--- a/tavern/_plugins/mqtt/response.py
+++ b/tavern/_plugins/mqtt/response.py
@@ -172,6 +172,13 @@ class MQTTResponse(BaseResponse):
             time_spent += time.time() - t0
 
         if msg:
+            if self.expected.get("unexpected"):
+                self._adderr(
+                    "Got '%s' on topic '%s' marked as unexpected",
+                    expected_payload,
+                    topic,
+                )
+
             self._maybe_run_validate_functions(msg)
         else:
             self._adderr(

--- a/tavern/schemas/tests.schema.yaml
+++ b/tavern/schemas/tests.schema.yaml
@@ -88,6 +88,9 @@ schema;stage:
       type: map
       required: false
       mapping:
+        unexpected:
+          type: bool
+          required: false
         topic:
           type: str
           required: true

--- a/tests/unit/response/test_mqtt_response.py
+++ b/tests/unit/response/test_mqtt_response.py
@@ -104,3 +104,18 @@ class TestResponse(object):
         assert len(verifier.received_messages) == 2
         assert verifier.received_messages[0].topic == fake_message_bad.topic
         assert verifier.received_messages[1].topic == fake_message_good.topic
+
+    def test_unexpected_fail(self, includes):
+        """Messages marked unexpected fail test"""
+
+        expected = {"topic": "/a/b/c", "payload": "hello", "unexpected": True}
+
+        fake_message = FakeMessage(expected)
+
+        verifier = self._get_fake_verifier(expected, [fake_message], includes)
+
+        with pytest.raises(exceptions.TestFailError):
+            verifier.verify(expected)
+
+        assert len(verifier.received_messages) == 1
+        assert verifier.received_messages[0].topic == fake_message.topic


### PR DESCRIPTION
cherry pick from 2.0 branch