### PR TITLE
Add py as dependency to remeditate AttributeError: module 'py' has no attribute 'io'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ pyjwt>=2.4.0,<3
 paho-mqtt>=1.3.1,<=1.6.1
 jmespath<1
 pytest>=6.2,<8
+py
 python-box>4,<6
 stevedore
 

--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -17,6 +17,7 @@ changedir =
     generic: tests/integration
     noextra: tests/integration
 deps =
+    py
     docker-compose
     flask
     allure-pytest

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist = py37,py38,py39,py310,py39lint,py39black,py39mypy,py39-pytest6
 skip_missing_interpreters = true
 
 [testenv]
+deps =
+    py
 extras =
     tests
 commands =


### PR DESCRIPTION
See #816 .

pytest has removed py as a dependency as of 7.2.0 (https://github.com/pytest-dev/pytest/pull/10396), but tavern still requires it. Test failures produce an internal error `AttributeError: module 'py' has no attribute 'io'` without this dependency.

