### PR TITLE
mqtt: fix unexpected behaviour

### DIFF
--- a/tavern/_plugins/mqtt/response.py
+++ b/tavern/_plugins/mqtt/response.py
@@ -181,11 +181,14 @@ class MQTTResponse(BaseResponse):
 
             self._maybe_run_validate_functions(msg)
         else:
-            self._adderr(
-                "Expected '%s' on topic '%s' but no such message received",
-                expected_payload,
-                topic,
-            )
+            if self.expected.get("unexpected"):
+                return {}
+            else:
+                self._adderr(
+                    "Expected '%s' on topic '%s' but no such message received",
+                    expected_payload,
+                    topic,
+                )
 
         if self.errors:
             if warnings:


### PR DESCRIPTION
Currently mqtt_response with the unexpected key set to true fails if no message is received. This is strange, was we don't expect a message, and should only fail if a message is received.

Formatted stage:
  mqtt_publish:
    payload: 10.10.10.10
    topic: inet6/add
  mqtt_response:
    payload: !anything ''
    timeout: 5
    topic: vallumd/will
    unexpected: true

Errors:
E   tavern.util.exceptions.TestFailError: Test 'add IPv4 IP to IPv6 ipset' failed:
    - Expected '<Tavern YAML sentinel for anything>' on topic 'vallumd/will' but no such message received

Fix this by suppressing the error MQTTResponse._await_response() and returning an empty dict if the unexpected key is set.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>