### PR TITLE
fix: Allow changing request variables in hook

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,10 @@
+import logging
+from collections.abc import Iterable
+
 import pytest
+from box import Box
+
+from tavern._core import exceptions
 
 
 @pytest.fixture
@@ -31,3 +37,16 @@ def fixture_echo_url():
 @pytest.fixture(scope="session", autouse=True, name="autouse_thing_named")
 def second(autouse_thing):
     return autouse_thing
+
+
+def pytest_tavern_beta_before_every_request(request_args: Box):
+    logging.info("Making request: %s", request_args)
+
+    if not isinstance(request_args.get("json"), Iterable):
+        return
+
+    if "PLEASE ADD DATA HERE" in request_args["json"]:
+        request_args["json"] = {"value": 123}
+
+    if "PLEASE FAIL THIS TEST" in request_args["json"]:
+        raise exceptions.TestFailError("I was asked to fail this test")

--- a/tests/integration/test_hooks.tavern.yaml
+++ b/tests/integration/test_hooks.tavern.yaml
@@ -1,0 +1,34 @@
+---
+test_name: Test hook adding data
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: do something
+    request:
+      method: POST
+      url: "{host}/echo"
+      json: "PLEASE ADD DATA HERE"
+    response:
+      status_code: 200
+      json:
+        value: 123
+
+---
+test_name: Test hook causing a failure
+
+_xfail:
+  run: I was asked to fail this test
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: do something
+    request:
+      method: POST
+      url: "{host}/echo"
+      json: "PLEASE FAIL THIS TEST"
+    response:
+      status_code: 500

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -666,3 +666,25 @@ def test_copy_config(pytestconfig):
     cfg_2 = load_global_cfg(pytestconfig)
 
     assert cfg_2.variables.get("test1") is None
+class TestHooks:
+    def test_before_every_request_hook_called(self, fulltest, mockargs, includes):
+        """Verify that the before_every_request hook is called"""
+        mock_response = Mock(**mockargs)
+        
+        # Mock the hook caller
+        hook_mock = Mock()
+        includes.tavern_internal.pytest_hook_caller.pytest_tavern_beta_before_every_request = hook_mock
+
+        with patch(
+            "tavern._plugins.rest.request.requests.Session.request",
+            return_value=mock_response,
+        ) as pmock:
+            run_test("heif", fulltest, includes)
+
+        # Verify the hook was called with the request arguments
+        hook_mock.assert_called_once()
+        # Verify the request args passed to hook contain the expected values
+        assert "url" in hook_mock.call_args[1]
+        assert "method" in hook_mock.call_args[1]
+        assert hook_mock.call_args[1]["method"] == "GET"
+        assert "http://www.google.com" in hook_mock.call_args[1]["url"]

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -666,11 +666,13 @@ def test_copy_config(pytestconfig):
     cfg_2 = load_global_cfg(pytestconfig)
 
     assert cfg_2.variables.get("test1") is None
+
+
 class TestHooks:
     def test_before_every_request_hook_called(self, fulltest, mockargs, includes):
         """Verify that the before_every_request hook is called"""
         mock_response = Mock(**mockargs)
-        
+
         # Mock the hook caller
         hook_mock = Mock()
         includes.tavern_internal.pytest_hook_caller.pytest_tavern_beta_before_every_request = hook_mock
@@ -678,13 +680,14 @@ class TestHooks:
         with patch(
             "tavern._plugins.rest.request.requests.Session.request",
             return_value=mock_response,
-        ) as pmock:
-            run_test("heif", fulltest, includes)
+        ):
+            run_test("test_file_name", fulltest, includes)
 
         # Verify the hook was called with the request arguments
         hook_mock.assert_called_once()
         # Verify the request args passed to hook contain the expected values
-        assert "url" in hook_mock.call_args[1]
-        assert "method" in hook_mock.call_args[1]
-        assert hook_mock.call_args[1]["method"] == "GET"
-        assert "http://www.google.com" in hook_mock.call_args[1]["url"]
+        request_args = hook_mock.call_args[1]["request_args"]
+        assert "url" in request_args
+        assert "method" in request_args
+        assert request_args["method"] == "GET"
+        assert "http://www.google.com" in request_args["url"]

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -673,8 +673,11 @@ class TestHooks:
         """Verify that the before_every_request hook is called"""
         mock_response = Mock(**mockargs)
 
+        def call_func(request_args):
+            request_args["headers"] = {"foo": "myzclqkptpk"}
+
         # Mock the hook caller
-        hook_mock = Mock()
+        hook_mock = Mock(side_effect=call_func)
         includes.tavern_internal.pytest_hook_caller.pytest_tavern_beta_before_every_request = hook_mock
 
         with patch(
@@ -685,9 +688,12 @@ class TestHooks:
 
         # Verify the hook was called with the request arguments
         hook_mock.assert_called_once()
+
         # Verify the request args passed to hook contain the expected values
         request_args = hook_mock.call_args[1]["request_args"]
         assert "url" in request_args
         assert "method" in request_args
         assert request_args["method"] == "GET"
         assert "http://www.google.com" in request_args["url"]
+
+        assert request_args["headers"] == {"foo": "myzclqkptpk"}


### PR DESCRIPTION
Don't copy data and instead return the underlying Box to allow changing request data 