### PR TITLE
feat: add support for anynumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# UNRELEASED
+
+- Add !anynumber type sentinel for matching both integers and floats in responses
+
 ##  0.1.2           Allow sending/validation of JSON lists (2017-11-21)
 
 ##  0.1.3           Fix global configuration loading via pytest command line (2017-12-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-# UNRELEASED
-
-- Add !anynumber type sentinel for matching both integers and floats in responses
-
 ##  0.1.2           Allow sending/validation of JSON lists (2017-11-21)
 
 ##  0.1.3           Fix global configuration loading via pytest command line (2017-12-05)

--- a/docs/source/basics.md
+++ b/docs/source/basics.md
@@ -1490,6 +1490,7 @@ but will be removed in a future release, and should raise a warning.
 If you want to make sure that the key returned is of a specific type, you can
 use one of the following markers instead:
 
+- `!anynumber`: Matches any number (integer or float)
 - `!anyint`: Matches any integer
 - `!anyfloat`: Matches any float (note that this will NOT match integers!)
 - `!anystr`: Matches any string

--- a/tavern/_core/dict_util.py
+++ b/tavern/_core/dict_util.py
@@ -415,7 +415,10 @@ def check_keys_match_recursive(
     elif isinstance(expected_val, TypeSentinel):
         # If the 'expected' type is actually just a sentinel for another type,
         # then it should match
-        expected_matches = expected_val.constructor == actual_type
+        if isinstance(expected_val.constructor, tuple):
+            expected_matches = actual_type in expected_val.constructor
+        else:
+            expected_matches = actual_type == expected_val.constructor
     else:
         # Normal matching
         expected_matches = (

--- a/tavern/_core/loader.py
+++ b/tavern/_core/loader.py
@@ -198,6 +198,11 @@ class TypeSentinel(yaml.YAMLObject):
         return node
 
 
+class NumberSentinel(TypeSentinel):
+    yaml_tag = "!anynumber"
+    constructor = (int, float)  # Tuple of allowed types
+
+
 class IntSentinel(TypeSentinel):
     yaml_tag = "!anyint"
     constructor = int

--- a/tests/integration/server.py
+++ b/tests/integration/server.py
@@ -54,6 +54,7 @@ def get_fake_dictionary():
     fake = {
         "top": {"Thing": "value", "nested": {"doubly": {"inner": "value"}}},
         "an_integer": 123,
+        "a_float": 1.23,
         "a_string": "abc",
         "a_bool": True,
     }

--- a/tests/integration/test_jmes.tavern.yaml
+++ b/tests/integration/test_jmes.tavern.yaml
@@ -21,6 +21,12 @@ stages:
             - jmespath: "an_integer"
               operator: "type"
               expected: int
+            - jmespath: "a_float"
+              operator: "eq"
+              expected: 1.23
+            - jmespath: "a_float"
+              operator: "type"
+              expected: float
             - jmespath: "a_string"
               operator: "eq"
               expected: abc

--- a/tests/integration/test_save_dict_value.tavern.yaml
+++ b/tests/integration/test_save_dict_value.tavern.yaml
@@ -5,6 +5,7 @@
 #     doubly:
 #       inner: value
 # an_integer: 123
+# a_float: 1.23
 # a_string: abc
 # a_bool: true
 

--- a/tests/integration/test_strict_key_checks.tavern.yaml
+++ b/tests/integration/test_strict_key_checks.tavern.yaml
@@ -5,6 +5,7 @@
 #     doubly:
 #       inner: value
 # an_integer: 123
+# a_float: 1.23
 # a_string: abc
 # a_bool: true
 
@@ -91,6 +92,7 @@ stages:
             doubly:
               inner: value
         an_integer: 123
+        a_float: 1.23
         a_string: abc
         # missing
         # a_bool: true
@@ -119,6 +121,7 @@ stages:
         #     doubly:
         #       inner: value
         an_integer: 123
+        a_float: 1.23
         a_string: abc
         a_bool: true
 
@@ -145,6 +148,7 @@ stages:
         #     doubly:
         #       inner: value
         an_integer: 123
+        a_float: 1.23
         a_string: abc
         a_bool: true
 
@@ -172,6 +176,7 @@ stages:
             doubly:
               inner: value
         an_integer: 123
+        a_float: 1.23
         a_string: abc
         # missing
         # a_bool: true
@@ -198,6 +203,7 @@ stages:
             doubly:
               inner: value
         an_integer: 123
+        a_float: 1.23
         a_string: abc
         a_bool: true
 
@@ -223,6 +229,7 @@ stages:
             doubly:
               inner: value
         an_integer: 123
+        a_float: 1.23
         a_string: abc
         a_bool: true
 
@@ -248,6 +255,7 @@ stages:
             doubly:
               inner: value
         an_integer: 123
+        a_float: 1.23
         a_string: abc
         # a_bool: true
 
@@ -265,6 +273,7 @@ stages:
             doubly:
               inner: value
         an_integer: 123
+        a_float: 1.23
         a_string: abc
         a_bool: true
 
@@ -280,6 +289,7 @@ stages:
             doubly:
               inner: value
         # an_integer: 123
+        a_float: 1.23
         a_string: abc
         a_bool: true
 

--- a/tests/integration/test_typetokens.tavern.yaml
+++ b/tests/integration/test_typetokens.tavern.yaml
@@ -163,6 +163,7 @@ stages:
           Thing: !anystr
           nested: !anything
         an_integer: !anyint
+        a_float: !anyfloat
         a_string: !anystr
         a_bool: !anybool
 
@@ -704,3 +705,55 @@ stages:
       status_code: 200
       json:
         uuid: !re_fullmatch "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+
+---
+test_name: Test number type match
+
+strict:
+  - json:off
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: match integer value
+    request:
+      url: "{host}/fake_dictionary"
+      method: GET
+    response:
+      status_code: 200
+      json:
+        an_integer: !anynumber
+
+  - name: match float value
+    request:
+      url: "{host}/fake_dictionary"
+      method: GET
+    response:
+      status_code: 200
+      json:
+        a_float: !anynumber
+
+---
+test_name: Test number type match in list
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: Match generic number types
+    request:
+      url: "{host}/fake_list"
+      method: GET
+    response:
+      status_code: 200
+      json:
+        - a
+        - b
+        - c
+        - !anynumber
+        - !anynumber
+        - !anynumber
+        - !anynumber
+        - !anynumber
+        - !anynumber

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -23,6 +23,7 @@ from tavern._core.loader import (
     IncludeLoader,
     IntSentinel,
     ListSentinel,
+    NumberSentinel,
     StrSentinel,
     construct_include,
     load_single_document_yaml,
@@ -205,6 +206,8 @@ class TestMatchRecursive:
             (DictSentinel(), {2: 2}),
             (FloatSentinel(), 4.5),
             (StrSentinel(), "dood"),
+            (NumberSentinel(), 2),
+            (NumberSentinel(), 2.5),
         ],
     )
     def test_type_token_matches(self, token, response):
@@ -219,6 +222,10 @@ class TestMatchRecursive:
             (DictSentinel(), [4, 5, 6]),
             (FloatSentinel(), "4"),
             (StrSentinel(), {"a": 2}),
+            (NumberSentinel(), "2"),
+            (NumberSentinel(), [1]),
+            (NumberSentinel(), {"val": 1}),
+            (NumberSentinel(), True),
         ],
     )
     def test_type_token_no_match_errors(self, token, response):


### PR DESCRIPTION
## Problem
JSON does not differentiate natively between floats and ints. Depending on how the server formats the response for a number, we may receive `23` and `23.4` in the same field
Whole value
```json
{
    "a_number_field": 23
}
``` 

Fractional value
```json
{
    "a_number_field": 23.4
}
```

Existing type matchers `!anyint` and `!anyfloat` do not work for a test that has no control over the exact value in the response. Because `!anyfloat` does not accept a whole number in response, failing with error (_formatting is mine for better readability_):
```
tavern._core.exceptions.KeyMismatchError: Type of returned data was different than expected (
  expected["a_number_field"] = '<Tavern YAML sentinel for <class 'float'>>' (
    type = <class 'tavern._core.loader.FloatSentinel'>
  ),
  actual["a_number_field"] = '23' (type = <class 'int'>)
)
```
That forces us to use `!anything`, which is less restrictive.

## Solution
This PR introduces a new `!anynumber` type matcher that would match both ints and floats