### PR TITLE
Fix skip stage unit tests

### DIFF
--- a/tests/unit/test_skip.py
+++ b/tests/unit/test_skip.py
@@ -80,9 +80,9 @@ class TestSkipStage:
         """Don't skip stage when using a variable that evaluates to False"""
 
         stage["skip"] = "'{some_var}' == 'value'"
-        test_block_config.variables.update({"some_var": "value"})
+        test_block_config.variables.update({"some_var": "not_value"})
 
-        assert _run_test(stage, test_block_config, run_mock) is False
+        assert _run_test(stage, test_block_config, run_mock) is True
 
     def test_skip_invalid_var_types(self, stage, test_block_config, run_mock):
         """Error when cel types are wrong"""


### PR DESCRIPTION
Correct `test_skip_env_var_false` to actually test the false case 

@michaelboulton  please review this PR for issue #1019 . 

thnx!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for skip functionality to reflect corrected behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->