### PR TITLE
docs: fix missing closing quote in file_body example and clarify path resolution

### DIFF
--- a/docs/source/http.md
+++ b/docs/source/http.md
@@ -393,10 +393,12 @@ formats the `file_body` key can be used:
     request:
       url: "{host}/data_blob"
       method: POST
-      file_body: "/path/to/blobfile
+      file_body: "/path/to/blobfile"
     response:
       status_code: 200
 ```
+
+The path can be absolute or relative to the directory of the test file.
 
 Like the `files` key, this is mutually exclusive with the `json` key.
 


### PR DESCRIPTION
## Summary

The YAML code example for `file_body` in the HTTP docs was missing a closing `"` on the path string, making the example invalid YAML.

Also added a one-line note clarifying that the path can be absolute or relative to the test file's directory — this directly addresses the recurring confusion reported in #637.

## Changes

- `docs/source/http.md`: Added missing closing `"` on `file_body` path in code example
- - `docs/source/http.md`: Added note: _"The path can be absolute or relative to the directory of the test file."_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Fixed an example in the documentation for binary blob uploads.
  * Clarified that file paths can be specified as absolute or relative to the test file directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->