### PR TITLE
docs: add note about unmatched braces in format strings

### DIFF
--- a/docs/source/basics.md
+++ b/docs/source/basics.md
@@ -204,14 +204,16 @@ request:
     graphql_query: "{%raw%}{{ user(id: 123) {{ first_name }} }}{%endraw%}"
 ```
 
-**NOTE**: This is a toy example, if you want to use GraphQL with tavern then 
+**NOTE**: This is a toy example, if you want to use GraphQL with tavern then
 head over to the [GraphQL docs](./graphql.md).
 
 **NOTE**: If a string value contains an unmatched `{` that is not a valid
-format placeholder (for example, an MQTT payload value like `{Explanation 1`),
-Tavern will log a warning and pass the string through unformatted rather than
-raising an error. To avoid unexpected behaviour, always escape literal curly
-braces as described above.
+format placeholder, Tavern will log a warning and pass the string through
+unformatted rather than raising an error. For example, an MQTT payload value
+like `{Explanation 1` would be passed through unchanged (logged as a warning),
+whereas `{{Explanation 1}}` would be formatted to the literal string
+`{Explanation 1}`. To avoid unexpected behaviour, always escape literal curly
+braces as `{{` and `}}` as described above.
 
 Since `0.5.0`, Tavern also has some 'magic' variables available in the `tavern`
 key for formatting.

--- a/docs/source/basics.md
+++ b/docs/source/basics.md
@@ -207,6 +207,12 @@ request:
 **NOTE**: This is a toy example, if you want to use GraphQL with tavern then 
 head over to the [GraphQL docs](./graphql.md).
 
+**NOTE**: If a string value contains an unmatched `{` that is not a valid
+format placeholder (for example, an MQTT payload value like `{Explanation 1`),
+Tavern will log a warning and pass the string through unformatted rather than
+raising an error. To avoid unexpected behaviour, always escape literal curly
+braces as described above.
+
 Since `0.5.0`, Tavern also has some 'magic' variables available in the `tavern`
 key for formatting.
 

--- a/tavern/_core/dict_util.py
+++ b/tavern/_core/dict_util.py
@@ -70,7 +70,15 @@ def _check_and_format_values(to_format: str, box_vars: Box) -> str:
                     type(would_replace),
                 )
 
-    return to_format.format(**box_vars)
+    try:
+        return to_format.format(**box_vars)
+    except ValueError as e:
+        logger.warning(
+            "Failed to format string '%s': %s - passing through unformatted",
+            to_format,
+            e,
+        )
+        return to_format
 
 
 def _attempt_find_include(to_format: str, box_vars: box.Box) -> str | None:

--- a/tavern/_core/dict_util.py
+++ b/tavern/_core/dict_util.py
@@ -45,7 +45,15 @@ def _check_and_format_values(to_format: str, box_vars: Box) -> str:
         Formatted string with variables replaced by their values
     """
     formatter = string.Formatter()
-    would_format = formatter.parse(to_format)
+    try:
+        would_format = list(formatter.parse(to_format))
+    except ValueError as e:
+        logger.warning(
+            "Failed to parse format string '%s': %s - passing through unformatted",
+            to_format,
+            e,
+        )
+        return to_format
 
     for _, field_name, _, _ in would_format:
         if field_name is None:


### PR DESCRIPTION
Related to #733

The existing docs explain how to escape literal `{` and `}` using `{{` and `}}`. However they don't mention what happens when a string contains an **unmatched** brace (e.g. `{Explanation 1` from an MQTT payload), which previously caused an unhandled `ValueError`.

Adds a short `**NOTE**` paragraph after the existing escaping example to explain that strings with unmatched braces will log a warning and be passed through unformatted rather than raising an error, and directs users to escape literal braces to avoid unexpected behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation now clarifies string formatting behaviour when encountering unmatched curly braces. The guidance specifies that Tavern will emit a warning and pass strings through without formatting, rather than failing. Comprehensive guidance provided on escaping literal curly braces to prevent unexpected formatting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->