### PR TITLE
docs: fix outdated --tavern-merge-ext-function-values documentation (…

### DIFF
--- a/docs/source/core_concepts/external_code.md
+++ b/docs/source/core_concepts/external_code.md
@@ -257,8 +257,8 @@ This can be used as so:
 ```
 
 By default, using the `$ext` key will replace anything already present in that block.
-Input from external functions can be merged into a request instead by specifying the
-`tavern-merge-ext-function-values` option in your pytest.ini or on the command line:
+Input from external functions are always merged into a request by default.
+merged into the request by default. The `--tavern-merge-ext-function-values` flag has been removed - this is now the default behaviour:
 
 ```python
 # ext_functions.py

--- a/docs/source/core_concepts/external_code.md
+++ b/docs/source/core_concepts/external_code.md
@@ -5,17 +5,17 @@ strengths and is suited to different scenarios.
 
 | **Approach**                       | **Benefits**                                                                                                                                                                                                                 | **Downsides**                                                                                                                    | **Best Used When**                                                                                                                                                                                            |
 |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **External Functions** (`$ext`)    | • Flexible placement (request, response, save blocks)<br>• Can inject dynamic data or save custom data for validation in Python<br>• Can express complex logic specific to one test<br>• No special decorators needed        | • Functions must be in Python path                                                                                               | • Need dynamic data injection (e.g., calculated auth tokens)<br>• Custom response validation beyond key checking<br>• Extracting/transforming specific data from responses<br>• One-off test-specific logic   |
-| **Pytest Fixtures**                | • Integrates with pytest ecosystem<br>• Automatic discovery via conftest.py<br>• Can use `autouse` for implicit availability<br>• Session-scoped fixtures compute once and reuse<br>• Return values available for formatting | • Limited to function/session scope fixtures (not per-stage)                                                                     | • Sharing setup data across entire test<br>• Loading configuration/credentials once<br>• Timing/logging entire test execution<br>• Leveraging existing pytest fixtures<br>• Need session-wide computed values |
-| **Tinctures**                      | • **Can run per-stage or per-test**<br>• Can introspect both request and response<br>• Access to stage dictionary                                                                                                            | • Less powerful than fixtures                                                                                                    | • Wrapping stage execution with setup/teardown<br>• Per-stage validation or logging<br>• Need access to both expected and actual response<br>• Reusable stage-level logic                                     |
-| **Hooks** (`pytest_tavern_beta_*`) | • Suite-wide automatic execution<br>• Multiple hook points (before test, after response, etc.)<br>• No explicit test modification needed<br>• Good for cross-cutting concerns                                                | • **'Beta'/unstable API** (names may change in future)<br>• Runs for ALL tests (less granular)<br>• Can't be turned off per-test | • Suite-wide logging/monitoring<br>• Global cleanup operations<br>• Recording all responses for debugging<br>• Adding test-wide configuration                                                                 |
+| **External Functions** (`$ext`)    | â¢ Flexible placement (request, response, save blocks)<br>â¢ Can inject dynamic data or save custom data for validation in Python<br>â¢ Can express complex logic specific to one test<br>â¢ No special decorators needed        | â¢ Functions must be in Python path                                                                                               | â¢ Need dynamic data injection (e.g., calculated auth tokens)<br>â¢ Custom response validation beyond key checking<br>â¢ Extracting/transforming specific data from responses<br>â¢ One-off test-specific logic   |
+| **Pytest Fixtures**                | â¢ Integrates with pytest ecosystem<br>â¢ Automatic discovery via conftest.py<br>â¢ Can use `autouse` for implicit availability<br>â¢ Session-scoped fixtures compute once and reuse<br>â¢ Return values available for formatting | â¢ Limited to function/session scope fixtures (not per-stage)                                                                     | â¢ Sharing setup data across entire test<br>â¢ Loading configuration/credentials once<br>â¢ Timing/logging entire test execution<br>â¢ Leveraging existing pytest fixtures<br>â¢ Need session-wide computed values |
+| **Tinctures**                      | â¢ **Can run per-stage or per-test**<br>â¢ Can introspect both request and response<br>â¢ Access to stage dictionary                                                                                                            | â¢ Less powerful than fixtures                                                                                                    | â¢ Wrapping stage execution with setup/teardown<br>â¢ Per-stage validation or logging<br>â¢ Need access to both expected and actual response<br>â¢ Reusable stage-level logic                                     |
+| **Hooks** (`pytest_tavern_beta_*`) | â¢ Suite-wide automatic execution<br>â¢ Multiple hook points (before test, after response, etc.)<br>â¢ No explicit test modification needed<br>â¢ Good for cross-cutting concerns                                                | â¢ **'Beta'/unstable API** (names may change in future)<br>â¢ Runs for ALL tests (less granular)<br>â¢ Can't be turned off per-test | â¢ Suite-wide logging/monitoring<br>â¢ Global cleanup operations<br>â¢ Recording all responses for debugging<br>â¢ Adding test-wide configuration                                                                 |
 
 **Quick Selection Guide:**
 
-- **Need it for just one test?** → External Functions or Tinctures
-- **Need pytest integration or session-wide data?** → Fixtures
-- **Need per-stage execution with timing/wrapping?** → Tinctures or Hooks
-- **Need it automatically for every test?** → Hooks or Fixtures
+- **Need it for just one test?** â External Functions or Tinctures
+- **Need pytest integration or session-wide data?** â Fixtures
+- **Need per-stage execution with timing/wrapping?** â Tinctures or Hooks
+- **Need it automatically for every test?** â Hooks or Fixtures
 
 ## Calling external functions
 
@@ -175,7 +175,7 @@ response:
 `check_jmespath_match` asserts that a JMESPath `query` resolves to a truthy value in the response. Optionally, an
 `expected`
 value can be provided to assert the result matches it exactly. Without `expected`, it asserts the path resolves to a
-truthy (non-falsy) value—falsy values like `[]`, `""`, `0`, and `False` will be treated as failures.
+truthy (non-falsy) valueâfalsy values like `[]`, `""`, `0`, and `False` will be treated as failures.
 
 ```yaml
 response:
@@ -256,9 +256,8 @@ This can be used as so:
     status_code: 200
 ```
 
-By default, using the `$ext` key will replace anything already present in that block.
-Input from external functions are always merged into a request by default.
-merged into the request by default. The `--tavern-merge-ext-function-values` flag has been removed - this is now the default behaviour:
+When an `$ext` function returns a mapping, its values are merged into the existing request block by default.
+The `--tavern-merge-ext-function-values` flag has been removed because this is now the default behaviour:
 
 ```python
 # ext_functions.py
@@ -277,16 +276,7 @@ def return_hello():
           function: ext_functions:return_hello
 ```
 
-If `tavern-merge-ext-function-values` is set, this will send "hello" and "goodbye" in
-the request. If not, it will just send "hello".
-
-Example `pytest.ini` setting `tavern-merge-ext-function-values` as an argument.
-
-```python
-# pytest.ini
-[pytest]
-addopts = --tavern - merge - ext - function - values 
-```
+This will send both "hello" and "goodbye" in the request.
 
 #### Saving data from a response
 


### PR DESCRIPTION
Fixes #854

## Problem
The documentation in `external_code.md` still referenced `--tavern-merge-ext-function-values` as an option users needed to set, but this flag was removed and merging external function values is now the default behaviour.

This caused users to get `error: unrecognized arguments: --tavern-merge-ext-function-values` when following the docs.

## Changes
- Updated line 260 to clarify that external function inputs are always merged into requests by default
- - Updated line 261 to note that the `--tavern-merge-ext-function-values` flag has been removed since this is now the default behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external functions documentation to reflect that values returned are now automatically merged into requests by default, simplifying configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->