### PR TITLE
fix: resolve deprecation warnings, typo, and xpassed tests

### DIFF
--- a/tavern/_plugins/mqtt/client.py
+++ b/tavern/_plugins/mqtt/client.py
@@ -296,7 +296,7 @@ class MQTTClient:
         """Add any messages received to the queue
 
         Todo:
-            If the queue is faull trigger an error in main thread somehow
+            If the queue is full trigger an error in main thread somehow
         """
 
         logger.info("Received mqtt message on %s", message.topic)

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -272,7 +272,6 @@ class TestContent:
             validate_content(nested_response, comparisons)
 
 
-@pytest.mark.xfail
 class TestPykwalifyExtension:
     def test_validate_schema_correct(self, nested_response):
         correct_schema = dedent(

--- a/tests/unit/test_marks.py
+++ b/tests/unit/test_marks.py
@@ -153,7 +153,7 @@ class TestAstNodeToLiteral:
         """Test converting ast.Dict nodes"""
 
         # Empty dict
-        node = ast.Dict(keys=[], values=[], ctx=ast.Load())
+        node = ast.Dict(keys=[], values=[])
         result = _ast_node_to_literal(node)
         assert result == {}
 
@@ -167,7 +167,6 @@ class TestAstNodeToLiteral:
                 ast.Constant(value="value1"),
                 ast.Constant(value=2),
             ],
-            ctx=ast.Load(),
         )
         result = _ast_node_to_literal(node)
         assert result == {"key1": "value1", "key2": 2}
@@ -176,7 +175,6 @@ class TestAstNodeToLiteral:
         inner_dict = ast.Dict(
             keys=[ast.Constant(value="inner_key")],
             values=[ast.Constant(value="inner_value")],
-            ctx=ast.Load(),
         )
         node = ast.Dict(
             keys=[
@@ -187,7 +185,6 @@ class TestAstNodeToLiteral:
                 ast.Constant(value="outer_value"),
                 inner_dict,
             ],
-            ctx=ast.Load(),
         )
         result = _ast_node_to_literal(node)
         assert result == {


### PR DESCRIPTION
gh pr create --title "fix: resolve deprecation warnings, typo, and xpassed tests" --body-file - <<'EOF'
## Summary
This PR addresses three minor issues in the codebase: Python 3.13+ deprecation warnings, a typo in documentation, and tests marked as xfail that are now passing.

## Changes Made

### 1. Fix Python 3.13+ Deprecation Warnings ([tests/unit/test_marks.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tests/unit/test_marks.py:0:0-0:0))
- **Issue:** [ast.Dict.__init__](cci:1://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_plugins/mqtt/client.py:122:4-289:50) deprecated the `ctx` parameter in Python 3.13+
- **Fix:** Removed `ctx=ast.Load()` from 4 `ast.Dict()` constructor calls
- **Lines changed:** 156, 170, 179, 190

### 2. Fix Typo in MQTT Client ([tavern/_plugins/mqtt/client.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_plugins/mqtt/client.py:0:0-0:0))
- **Issue:** Docstring contained typo "faull" instead of "full"
- **Fix:** Corrected to "If the queue is full trigger an error in main thread somehow"
- **Line:** 300

### 3. Fix xpassed Tests ([tests/unit/test_helpers.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tests/unit/test_helpers.py:0:0-0:0))
- **Issue:** [TestPykwalifyExtension](cci:2://file:///Users/satyasivasundarsalagrama/open-source/tavern/tests/unit/test_helpers.py:274:0-317:13) class was marked with `@pytest.mark.xfail` but tests are now passing
- **Fix:** Removed `@pytest.mark.xfail` decorator
- **Line:** 275

## Testing
- All modified tests pass successfully
- No new warnings introduced

## Checklist
- [x] Tests pass locally
- [x] No breaking changes
- [x] Minimal, focused changes
EOF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Re-enabled schema validation test cases that were previously skipped.
  * Updated test code to align with current testing framework expectations.

* **Documentation**
  * Fixed typo in inline code comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->