### PR TITLE
fix(helpers): wrap non-JSON parse errors in validate_pykwalify as Bad…

### DIFF
--- a/tavern/helpers.py
+++ b/tavern/helpers.py
@@ -107,7 +107,7 @@ def validate_pykwalify(response: requests.Response, schema: dict) -> None:
     """
     try:
         to_verify = response.json()
-    except TypeError as e:
+    except (TypeError, ValueError, json.JSONDecodeError) as e:
         raise exceptions.BadSchemaError(
             "Tried to match a pykwalify schema against a non-json response"
         ) from e

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -319,6 +319,20 @@ class TestPykwalifyExtension:
             )
 
 
+class TestValidatePykwalify:
+    def test_non_json_response_raises_bad_schema_error(self):
+        schema = yaml.load("type: map", Loader=yaml.SafeLoader)
+
+        class NonJsonResponse:
+            def json(self):
+                raise ValueError("not json")
+
+        with pytest.raises(exceptions.BadSchemaError) as exc_info:
+            validate_pykwalify(NonJsonResponse(), schema)
+
+        assert "non-json response" in str(exc_info.value)
+
+
 class TestCheckParseValues:
     @pytest.mark.parametrize("item", [yaml, yaml.load, yaml.SafeLoader])
     def test_warns_bad_type(self, item):


### PR DESCRIPTION
### Title: 
fix(helpers): wrap non-JSON parse errors in validate_pykwalify as BadSchemaError

### Description:

**validate_pykwalify()** in tavern/helpers.py only caught TypeError when calling response.json() , but non-JSON responses typically raise ValueError or json.JSONDecodeError . This caused raw parsing exceptions to leak out instead of being wrapped in the expected BadSchemaError.

### Bug behavior:

```
from tavern.helpers import 
validate_pykwalify

class NonJsonResponse:
    def json(self):
        raise ValueError("not json")

validate_pykwalify(NonJsonResponse(), 
{"type": "map"})
# Before: raises ValueError("not json")
# After:  raises BadSchemaError("Tried to 
match a pykwalify schema against a non-json 
response")
```
### Fix:

- Catch TypeError , ValueError , and json.JSONDecodeError in validate_pykwalify() and wrap them consistently as BadSchemaError .
- Add regression test TestValidatePykwalify::test_non_json_response_raises_bad_schema_error in tests/unit/test_helpers.py .
Verification:

```
uv run pytest tests/unit/test_helpers.py -k 
TestValidatePykwalify -vv
```
### Files changed:

- tavern/helpers.py – broadened exception handling in validate_pykwalify()
- tests/unit/test_helpers.py – added regression test for non-JSON response handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Enhanced error handling when processing invalid or non-JSON formatted responses, ensuring more accurate error messages are displayed to users regarding schema validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->