### PR TITLE
fix: suppress PytestCollectionWarning for TestConfig class

### DIFF
--- a/tavern/_core/pytest/config.py
+++ b/tavern/_core/pytest/config.py
@@ -19,6 +19,8 @@ class TavernInternalConfig:
 
 @dataclasses.dataclass(frozen=True)
 class TestConfig:
+    __test__ = False
+
     """Tavern configuration - there is a global config, then test-specific config, and
     finally stage-specific config, but they all use this structure
 


### PR DESCRIPTION
### Summary:
Added `__test__ = False` to the [TestConfig](cci:2://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_core/pytest/config.py:19:0-73:33) class in [tavern/_core/pytest/config.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_core/pytest/config.py:0:0-0:0) to prevent pytest from attempting to collect it as a test class.
 
**Problem:**
Pytest generates `PytestCollectionWarning: cannot collect test class 'TestConfig' because it has a __init__ constructor` on every test run because the class name starts with "Test".
 
**Fix:**
Added `__test__ = False` class attribute — the standard pytest convention to mark a class as not a test.
 
**Result:**
- Warnings reduced from 10 to 8 in unit test runs
- All 520 tests still pass
 
### Files Changed:
- [tavern/_core/pytest/config.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_core/pytest/config.py:0:0-0:0) (2 lines added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where pytest was incorrectly attempting to discover and execute the TestConfig class as a test class during test collection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taverntesting/tavern/pull/1045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->