### PR TITLE
docs: replace deprecated `py.test` command with `pytest` across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This can then be run like so:
 
 ```bash
 $ pip install tavern[pytest]
-$ py.test test_minimal.tavern.yaml  -v
+$ pytest test_minimal.tavern.yaml  -v
 =================================== test session starts ===================================
 platform linux -- Python 3.5.2, pytest-3.4.2, py-1.5.2, pluggy-0.6.0 -- /home/taverntester/.virtualenvs/tavernexample/bin/python3
 cachedir: .pytest_cache

--- a/docs/source/basics.md
+++ b/docs/source/basics.md
@@ -34,7 +34,7 @@ recommended) it is also possible to specify a custom regular expression to match
 filenames. For example, if you want to call all of your files
 `tavern_test_x.yaml`, `tavern_test_y.yaml`, etc. then use the
 `tavern-file-path-regex` option in the configuration file or on the command
-line. For example, `py.test --tavern-file-path-regex "tavern_test_.*.yaml"`
+line. For example, `pytest --tavern-file-path-regex "tavern_test_.*.yaml"`
 
 **test_name** is, as expected, the name of that test. If the pytest plugin is
 being used to run integration tests, this is what the test will show up as in

--- a/docs/source/core_concepts/config.md
+++ b/docs/source/core_concepts/config.md
@@ -370,15 +370,15 @@ at the command line using the `--tavern-global-cfg` flag. The variables in
 `common.yaml` will then be available for formatting in *all* tests during that
 test run.
 
-**NOTE**: `tavern-ci` is just an alias for `py.test` and
+**NOTE**: `tavern-ci` is just an alias for `pytest` and
 will take the same options.
 
 ```
 # These will all work
 $ tavern-ci --tavern-global-cfg=integration_tests/local_urls.yaml
 $ tavern-ci --tavern-global-cfg integration_tests/local_urls.yaml
-$ py.test --tavern-global-cfg=integration_tests/local_urls.yaml
-$ py.test --tavern-global-cfg integration_tests/local_urls.yaml
+$ pytest --tavern-global-cfg=integration_tests/local_urls.yaml
+$ pytest --tavern-global-cfg integration_tests/local_urls.yaml
 ```
 
 It might be tempting to put this in the 'addopts' section of the pytest.ini file
@@ -417,7 +417,7 @@ every test:
 # Note the '--' after all global configuration files are passed, indicating that
 # arguments after this are not global config files
 $ tavern-ci --tavern-global-cfg common.yaml test_urls.yaml -- test_server.tavern.yaml
-$ py.test --tavern-global-cfg common.yaml local_docker_urls.yaml -- test_server.tavern.yaml
+$ pytest --tavern-global-cfg common.yaml local_docker_urls.yaml -- test_server.tavern.yaml
 ```
 
 ```ini

--- a/docs/source/core_concepts/external_code.md
+++ b/docs/source/core_concepts/external_code.md
@@ -30,7 +30,7 @@ it is in the Python path. For example, if `utils.py` is in the 'tests' folder,
 you will need to run your tests something like (on Linux):
 
 ```shell
-$ PYTHONPATH=$PYTHONPATH:tests py.test tests/
+$ PYTHONPATH=$PYTHONPATH:tests pytest tests/
 ```
 
 ### Checking the response using external functions

--- a/docs/source/core_concepts/marks.md
+++ b/docs/source/core_concepts/marks.md
@@ -53,13 +53,13 @@ of backend processing so we don't want to run it on every test run. This can be
 selected like this:
 
 ```shell
-$ py.test -m "not slow"
+$ pytest -m "not slow"
 ```
 
 Conversely, if we just want to run all tests marked as 'fast', we can do this:
 
 ```shell
-$ py.test -m "fast"
+$ pytest -m "fast"
 ```
 
 Marks can only be applied to a whole test, not to individual stages (with the

--- a/docs/source/core_concepts/types.md
+++ b/docs/source/core_concepts/types.md
@@ -107,7 +107,7 @@ global strictness setting.
 
 ```shell
 # Enable strict checking for body and headers only
-py.test --tavern-strict json:on headers:on redirect_query_params:off -- my_test_folder/
+pytest --tavern-strict json:on headers:on redirect_query_params:off -- my_test_folder/
 ```
 
 #### In the Pytest config file

--- a/docs/source/debugging.md
+++ b/docs/source/debugging.md
@@ -117,7 +117,7 @@ from Tavern but we have an error in the yaml:
 Having full debug output can be a bit too much information, so we set up logging
 as above but at the `INFO` level rather than `DEBUG`.
 
-We run this by doing `py.test --tb=short -p no:logging` and get the following
+We run this by doing `pytest --tb=short -p no:logging` and get the following
 output:
 
 ```

--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -160,7 +160,7 @@ tests. Otherwise, you will need to point it to the folder containing the integra
 `setup.cfg/tox.ini/etc` so that Pytest's collection mechanism knows where to look.
 
 ```bash
-$ py.test
+$ pytest
 ============================= test session starts ==============================
 platform linux -- Python 3.5.2, pytest-3.2.0, py-1.4.34, pluggy-0.4.0
 rootdir: /home/developer/project/tests, inifile: setup.cfg

--- a/example/grpc/README.md
+++ b/example/grpc/README.md
@@ -26,7 +26,7 @@ The server runs two gRPC endpoints:
 
 2. In another terminal, run the tests:
    ```bash
-   py.test -v
+   pytest -v
    ```
 
 The test file (`tests/test_grpc.tavern.yaml`) demonstrates:

--- a/example/mqtt/README.md
+++ b/example/mqtt/README.md
@@ -14,5 +14,5 @@ The server queries this database when a `GET` request is made to
 
 The tavern test file includes examples of how to test such a setup, using the
 keys `mqtt_publish` and `mqtt_response`. Run `docker compose up --build` in one
-terminal and run `py.test` in another terminal, and output from the mosquitto
+terminal and run `pytest` in another terminal, and output from the mosquitto
 MQTT broker, the server, and the listener will be shown inline.


### PR DESCRIPTION
## What

Replaces all 14 occurrences of the deprecated `py.test` command with the current `pytest` command across the README, example READMEs, and documentation source files.

## Why

The `py.test` entry-point alias was deprecated in pytest 4.0 (released 2018) in favour of the `pytest` command. Using `py.test` in docs can confuse new users who follow the official pytest documentation, which exclusively uses `pytest`.

## Files changed

- `README.md` – quickstart code block
- `docs/source/basics.md` – file path regex example
- `docs/source/debugging.md` – debug run example
- `docs/source/examples.md` – running tests example
- `docs/source/core_concepts/config.md` – global config examples and the note about `tavern-ci` being an alias for `pytest` (not `py.test`)
- `docs/source/core_concepts/external_code.md` – PYTHONPATH example
- `docs/source/core_concepts/marks.md` – mark filter examples
- `docs/source/core_concepts/types.md` – strict mode example
- `example/grpc/README.md` – gRPC example instructions
- `example/mqtt/README.md` – MQTT example instructions

## Verification

After the change, a grep across all `.md` files returns no remaining `py.test` occurrences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation examples and Quickstart instructions across multiple README files and core guides to use the current `pytest` command syntax instead of the deprecated `py.test` alias. Changes include configuration, debugging, marks, types, external code, and example project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->