### PR TITLE
fix(error): handle import compatibility for FormattedExcinfo from pytest

### DIFF
--- a/tavern/_core/pytest/error.py
+++ b/tavern/_core/pytest/error.py
@@ -13,7 +13,7 @@ from _pytest._code.code import TerminalRepr
 try:
     from _pytest._code.code import FormattedExcinfo
 except ImportError:
-    from pytest import ExceptionInfo as FormattedExcinfo
+    from _pytest._code.code import ExceptionInfoFormatter as FormattedExcinfo
 from _pytest._io import TerminalWriter
 
 from tavern._core import exceptions

--- a/tavern/_core/pytest/error.py
+++ b/tavern/_core/pytest/error.py
@@ -8,7 +8,12 @@ from io import StringIO
 from typing import Any
 
 import yaml
-from _pytest._code.code import FormattedExcinfo, TerminalRepr
+from _pytest._code.code import TerminalRepr
+
+try:
+    from _pytest._code.code import FormattedExcinfo
+except ImportError:
+    from pytest import ExceptionInfo as FormattedExcinfo
 from _pytest._io import TerminalWriter
 
 from tavern._core import exceptions


### PR DESCRIPTION
closes https://github.com/taverntesting/tavern/issues/1054

Import new FormattedExcinfo for newr versions of pytst

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compatibility with different Pytest versions through resilient dependency imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->