### PR TITLE
fix: replace deprecated distutils.spawn with shutil.which and fix typos

### DIFF
--- a/tavern/_core/extfunctions.py
+++ b/tavern/_core/extfunctions.py
@@ -26,7 +26,7 @@ def get_pykwalify_logger(module: str | None) -> logging.Logger:
     """Get logger for this module
 
     Have to do it like this because the way that pykwalify load extension
-    modules means that getting the logger the normal way just result sin it
+    modules means that getting the logger the normal way just results in it
     trying to get the root logger which won't log correctly
 
     Args:

--- a/tavern/_core/schema/extensions.py
+++ b/tavern/_core/schema/extensions.py
@@ -460,7 +460,7 @@ def validate_http_method(value: str, rule_obj, path) -> bool:
     if value not in valid_http_methods:
         logger = get_pykwalify_logger("tavern.schemas.extensions")
         logger.debug(
-            "Givern HTTP method '%s' was not one of %s - assuming it will be templated",
+            "Given HTTP method '%s' was not one of %s - assuming it will be templated",
             value,
             valid_http_methods,
         )

--- a/tavern/_plugins/grpc/protos.py
+++ b/tavern/_plugins/grpc/protos.py
@@ -3,11 +3,11 @@ import hashlib
 import importlib.util
 import logging
 import os
+import shutil
 import string
 import subprocess
 import sys
 import tempfile
-from distutils.spawn import find_executable
 from importlib.machinery import ModuleSpec
 
 from tavern._core import exceptions
@@ -21,7 +21,7 @@ def find_protoc() -> str:
     if "PROTOC" in os.environ and os.path.exists(os.environ["PROTOC"]):
         return os.environ["PROTOC"]
 
-    if protoc := find_executable("protoc"):
+    if protoc := shutil.which("protoc"):
         return protoc
 
     raise exceptions.ProtoCompilerException(

--- a/tavern/_plugins/rest/request.py
+++ b/tavern/_plugins/rest/request.py
@@ -66,7 +66,7 @@ def get_file_arguments(
 
 
 def get_request_args(rspec: dict, test_block_config: TestConfig) -> dict:
-    """Format the test spec given values inthe global config
+    """Format the test spec given values in the global config
 
     Todo:
         Add similar functionality to validate/save $ext functions so input


### PR DESCRIPTION
### Summary

`distutils` was deprecated in Python 3.10 and removed from the standard library in Python 3.12. The `find_executable` function from `distutils.spawn` is used in [tavern/_plugins/grpc/protos.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_plugins/grpc/protos.py:0:0-0:0) to locate the `protoc` binary. This PR replaces it with `shutil.which()`, the standard library equivalent available since Python 3.3.

Additionally fixes three minor typos in docstrings/log messages.

### Changes

| File | Change |
|------|--------|
| [tavern/_plugins/grpc/protos.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_plugins/grpc/protos.py:0:0-0:0) | Replace `distutils.spawn.find_executable` with `shutil.which` |
| [tavern/_core/schema/extensions.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_core/schema/extensions.py:0:0-0:0) | Fix typo: "Givern" → "Given" |
| [tavern/_plugins/rest/request.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_plugins/rest/request.py:0:0-0:0) | Fix typo: "inthe" → "in the" |
| [tavern/_core/extfunctions.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_core/extfunctions.py:0:0-0:0) | Fix typo: "result sin it" → "results in it" |

### Testing

- All 529 unit tests pass, 7 xfailed (expected)
- No behavioral changes — `shutil.which` is a drop-in replacement for `find_executable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Protocol Compiler discovery mechanism has been updated to utilise current standard implementation methods instead of the previously-used legacy approach.

* **Documentation**
  * Multiple spelling and grammatical errors have been corrected throughout the codebase, including corrections to function docstrings, debug logging messages, and documentation text within core modules, schema definitions, and various plugin implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->