### PR TITLE
fix: correct attach_yaml name in MQTT request and simplify grpc warnings

### DIFF
--- a/tavern/_plugins/grpc/__init__.py
+++ b/tavern/_plugins/grpc/__init__.py
@@ -1,18 +1,5 @@
 import warnings
 
-# Shut up warnings caused by proto libraries
-warnings.filterwarnings(
-    "ignore", category=DeprecationWarning, module="pkg_resources", lineno=2804
-)
-warnings.filterwarnings(
-    "ignore", category=DeprecationWarning, module="pkg_resources", lineno=2309
-)
-warnings.filterwarnings(
-    "ignore", category=DeprecationWarning, module="pkg_resources", lineno=2870
-)
-warnings.filterwarnings(
-    "ignore", category=DeprecationWarning, module="pkg_resources", lineno=2349
-)
-warnings.filterwarnings(
-    "ignore", category=DeprecationWarning, module="pkg_resources", lineno=20
-)
+# Suppress DeprecationWarnings from pkg_resources used by proto libraries.
+# These come from transitive dependencies and are not actionable here.
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="pkg_resources")

--- a/tavern/_plugins/mqtt/request.py
+++ b/tavern/_plugins/mqtt/request.py
@@ -65,7 +65,7 @@ class MQTTRequest(BaseRequest):
     def run(self):
         attach_yaml(
             self._original_publish_args,
-            name="rest_request",
+            name="mqtt_request",
         )
 
         try:


### PR DESCRIPTION
## fix: correct attach_yaml name in MQTT request and simplify grpc warnings

### Summary

Two small, tangible fixes:

1. **Bug: Wrong `attach_yaml` name in MQTT request** — [mqtt/request.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_plugins/mqtt/request.py:0:0-0:0) used `name="rest_request"` (copy-paste from REST plugin) instead of `name="mqtt_request"`. This caused MQTT request payloads to be incorrectly labeled as `rest_request` in test reports and allure attachments.

2. **Bug: Fragile `pkg_resources` warning suppression** — [grpc/__init__.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_plugins/grpc/__init__.py:0:0-0:0) had 5 separate `warnings.filterwarnings` calls with hardcoded `lineno` values (e.g. `lineno=2804`). These line numbers are specific to a particular version of `pkg_resources` and silently stop working when the dependency updates. Replaced with a single module-level filter that suppresses all `DeprecationWarning` from `pkg_resources` regardless of line number.

### Changes

| File | Change |
|------|--------|
| [tavern/_plugins/mqtt/request.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_plugins/mqtt/request.py:0:0-0:0) | `name="rest_request"` → `name="mqtt_request"` |
| [tavern/_plugins/grpc/__init__.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/tavern/tavern/_plugins/grpc/__init__.py:0:0-0:0) | 5 hardcoded `lineno` filters → 1 module-level filter |

### Testing

- 530 passed, 7 xfailed
- ruff check + format: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy deprecation warnings from the gRPC plugin during normal use.
  * Corrected the YAML attachment label for MQTT requests so saved request data is identified more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->