### PR TITLE
fix: correct attach_yaml labels in MQTT request and response

### DIFF
--- a/tavern/_plugins/mqtt/request.py
+++ b/tavern/_plugins/mqtt/request.py
@@ -65,7 +65,7 @@ class MQTTRequest(BaseRequest):
     def run(self):
         attach_yaml(
             self._original_publish_args,
-            name="rest_request",
+            name="mqtt_request",
         )
 
         try:

--- a/tavern/_plugins/mqtt/response.py
+++ b/tavern/_plugins/mqtt/response.py
@@ -199,7 +199,7 @@ class MQTTResponse(BaseResponse):
                     "payload": msg.payload,
                     "timestamp": msg.timestamp,
                 },
-                name="rest_response",
+                name="mqtt_response",
             )
 
             found: list[int] = []


### PR DESCRIPTION
## fix: correct attach_yaml labels in MQTT request and response

### Summary

Both MQTT request and response used `rest_request`/`rest_response` as the `attach_yaml` name — a copy-paste error from the REST plugin. This caused MQTT payloads to be incorrectly labeled as REST in test reports and allure attachments.

### Changes

| File | Change |
|------|--------|
| `tavern/_plugins/mqtt/request.py:68` | `name="rest_request"` → `name="mqtt_request"` |
| `tavern/_plugins/mqtt/response.py:202` | `name="rest_response"` → `name="mqtt_response"` |

### Testing

- 23 MQTT unit tests passed
- ruff check: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MQTT test output labels so attached request and response details now use MQTT-specific names.
  * Improved the clarity of reported test artefacts by aligning their identifiers with the MQTT context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->