### PR TITLE
docker: run example and test containers as non-root user

### DIFF
--- a/example/graphql/Dockerfile
+++ b/example/graphql/Dockerfile
@@ -9,4 +9,8 @@ COPY . /app
 RUN uv sync
 
 ENV PYTHONPATH=/app/
+
+# Run as a non-root user for container security
+RUN groupadd --system app && useradd --system --uid 1001 --gid app --create-home app
+USER 1001
 CMD ["uv", "run", "uvicorn", "tavern_graphql_example.server:app", "--host", "0.0.0.0", "--port", "5010"]

--- a/example/grpc/Dockerfile
+++ b/example/grpc/Dockerfile
@@ -23,4 +23,8 @@ FROM base
 COPY --from=protos /app/*.py /app/
 
 ENV PYTHONPATH=.
+
+# Run as a non-root user for container security
+RUN groupadd --system app && useradd --system --uid 1001 --gid app --create-home app
+USER 1001
 CMD ["uv", "run", "/app/tavern_grpc_example/server.py"]

--- a/example/http/Dockerfile
+++ b/example/http/Dockerfile
@@ -9,4 +9,8 @@ COPY . /app
 RUN uv sync
 
 ENV PYTHONPATH=/app/
+
+# Run as a non-root user for container security
+RUN groupadd --system app && useradd --system --uid 1001 --gid app --create-home app
+USER 1001
 CMD ["uv", "run", "gunicorn", "--bind", "0.0.0.0:5000", "tavern_http_example.server:app"]

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -10,4 +10,8 @@ COPY server.py /
 
 ENV FLASK_APP=/server.py
 
+
+# Run as a non-root user for container security
+RUN groupadd --system app && useradd --system --uid 1001 --gid app --create-home app
+USER 1001
 CMD ["flask", "run", "--host=0.0.0.0"]


### PR DESCRIPTION
Add a non-root `USER` directive to the four Dockerfiles used by Tavern's examples and integration tests.

**What changes**

Each of `example/graphql/Dockerfile`, `example/grpc/Dockerfile`, `example/http/Dockerfile`, and `tests/integration/Dockerfile` now creates a system user (`app`, UID 1001) and drops privileges before the `CMD` instruction.

**Why**

Running containers as root is a well-known security risk. The numeric UID (`USER 1001`) also satisfies Kubernetes security policies that enforce `runAsNonRoot` and a specific `runAsUser` value, so these example containers can be used as-is inside restricted clusters.

No application behaviour is changed — only the effective UID inside the container.

---

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Example and integration containers now run as a dedicated non-root user by default, improving runtime isolation and reducing security risk.
- **Compatibility**
  - Existing container build processes and startup commands remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->