### PR TITLE
docs: re-enable mystmd docs dependency group

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,10 +85,10 @@ pre-commit run --all-files
 
 ## Building the documentation
 
-Run this standalone for now: https://github.com/jupyter-book/mystmd/issues/2082
+After syncing the venv as above (which installs the `docs` dependency group):
 
 ```bash
-uv tool run --from mystmd myst build --html
+uv run myst build --html
 ```
 
 ### Watching for changes
@@ -96,5 +96,5 @@ uv tool run --from mystmd myst build --html
 To automatically rebuild when files in the `docs/` folder change:
 
 ```bash
-uv tool run watchfiles "uv tool run --from mystmd myst build --html" --filter all docs myst.yml
+uv tool run watchfiles "uv run myst build --html" --filter all docs myst.yml
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,7 @@ dev = [
     "flask-httpauth>=4.8.1,<6",
 ]
 
-# When this is fixed, enable this https://github.com/jupyter-book/mystmd/issues/2082
-# docs = ["mystmd"]
+docs = ["mystmd"]
 
 [project.scripts]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1811,6 +1811,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mystmd"
+version = "1.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/c0/9c374af9d64ec3d5c4df09852e91f6677304e2916330d6e97a3352f0e94f/mystmd-1.3.6.tar.gz", hash = "sha256:a68773939a591e756b3f257346f7c7b7b57d0aed45f04bccef17bccbc253ddc1", size = 2571205, upload-time = "2024-08-31T03:33:19.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/04/160dcc78bdd2f28a2ff68c66cc95c779daec4bf3fce9930112b4f74464fd/mystmd-1.3.6-py3-none-any.whl", hash = "sha256:a24f1b414892c3bcc68ddb3b0d18776cdf78fe4d0089e74a62e97eab2ba3fdf1", size = 2602629, upload-time = "2024-08-31T03:33:17.104Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2900,6 +2909,9 @@ dev = [
     { name = "uv" },
     { name = "wheel" },
 ]
+docs = [
+    { name = "mystmd" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2962,6 +2974,7 @@ dev = [
     { name = "uv", specifier = ">=0.9.2" },
     { name = "wheel" },
 ]
+docs = [{ name = "mystmd" }]
 
 [[package]]
 name = "tavern-graphql-example"


### PR DESCRIPTION
Original issue fixed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation build instructions to use the configured environment directly.
  * Improved the documentation file-watching workflow.

* **Chores**
  * Enabled the documentation tooling dependency group for more consistent documentation builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->