### PR TITLE
fix: report parametrize values to allure so each test gets its own history id

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,8 @@ jobs:
             TOXCFG: tox-integration.ini
           - TOXENV: py3-graphql
             TOXCFG: tox-integration.ini
+          - TOXENV: py3-allure
+            TOXCFG: tox-integration.ini
 
     env:
       TOXENV: ${{ matrix.TOXENV }}
@@ -115,6 +117,14 @@ jobs:
         run: |
           uv sync --all-extras --all-packages
           uvx tox -c ${TOXCFG} -e ${TOXENV}
+
+      - name: Upload allure report
+        if: ${{ always() && matrix.TOXENV == 'py3-allure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: allure-report
+          path: example/allure/allure-report/index.html
+          if-no-files-found: error
 
   custom-backend-tests:
     name: Custom Backend Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,14 +137,6 @@ jobs:
       - name: Setup Bats and bats libs
         id: setup-bats
         uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # v4.0.0
-        with:
-          # The libraries have to live somewhere the runner user owns, otherwise
-          # they get installed with sudo and actions/cache can't untar them back.
-          # See https://github.com/bats-core/bats-action#about-caching
-          support-path: "${{ github.workspace }}/.bats-libs/bats-support"
-          assert-path: "${{ github.workspace }}/.bats-libs/bats-assert"
-          detik-path: "${{ github.workspace }}/.bats-libs/bats-detik"
-          file-path: "${{ github.workspace }}/.bats-libs/bats-file"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,9 @@ pytype_output
 out/
 **/*.iml
 
-allure/
+/allure/
+allure-results/
+allure-report/
 
 .ijwb/
 .pants.d/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Integration tests need Docker; they spin up example servers via `docker compose`
 ```bash
 uv run tox -c tox-integration.ini -e py3-generic     # tests/integration
 uv run tox -c tox-integration.ini -e py3-http        # example/http, likewise mqtt/grpc/graphql
+uv run tox -c tox-integration.ini -e py3-allure      # example/allure, generates an allure report
 ```
 
 `./scripts/smoke.bash` runs lint, unit tests and the integration envs except `py3-noextra`, and is the

--- a/example/allure/README.md
+++ b/example/allure/README.md
@@ -1,0 +1,26 @@
+# Allure example
+
+A couple of tests, one of them parametrized, run against the server from
+[the http example](../http) and reported with
+[allure](https://allurereport.org/).
+
+The parametrized test is the interesting one: Tavern generates a separate test item
+per combination, so each of them should appear as its own test case in the report
+rather than overwriting each other (see
+[#1078](https://github.com/taverntesting/tavern/issues/1078)).
+
+## Running it
+
+```bash
+docker compose up --build -d
+uv run pytest --alluredir=allure-results
+docker compose run --rm allure generate /allure-results --clean --single-file -o /allure-report
+docker compose down -v
+```
+
+This is what `tox -c tox-integration.ini -e py3-allure` does from the root of the repo.
+
+`--single-file` writes the whole report to `allure-report/index.html`, which can be
+opened directly in a browser - a normal multi-file allure report has to be served over
+HTTP. The report is written from inside the container, so the files in `allure-report`
+and `allure-results` are owned by root.

--- a/example/allure/docker-compose.yaml
+++ b/example/allure/docker-compose.yaml
@@ -1,0 +1,22 @@
+---
+services:
+  server:
+    build:
+      context: ../http
+      dockerfile: Dockerfile
+    ports:
+      - "5000:5000"
+
+  # Only used to turn the results written by allure-pytest into a report - not
+  # started by 'docker compose up', run it with 'docker compose run --rm allure'
+  allure:
+    image: frankescobar/allure-docker-service:2.35.1
+    profiles:
+      - report
+    entrypoint: ["allure"]
+    # The image runs as its own 'allure' user which has no way of writing to the
+    # mounted folders
+    user: "0:0"
+    volumes:
+      - ./allure-results:/allure-results
+      - ./allure-report:/allure-report

--- a/example/allure/tests/common.yaml
+++ b/example/allure/tests/common.yaml
@@ -1,0 +1,26 @@
+---
+name: Allure example includes
+description: variables and the login stage used by the tests in this folder
+
+variables:
+  service: http://localhost:5000
+  user:
+    user: test-user
+    pass: correct-password
+
+stages:
+  - id: login_get_token
+    name: Login and acquire token
+    request:
+      url: "{service:s}/login"
+      json:
+        user: "{user.user:s}"
+        password: "{user.pass:s}"
+      method: POST
+      headers:
+        content-type: application/json
+    response:
+      status_code: 200
+      save:
+        json:
+          test_login_token: token

--- a/example/allure/tests/test_hello.tavern.yaml
+++ b/example/allure/tests/test_hello.tavern.yaml
@@ -1,0 +1,29 @@
+---
+# Each of these should show up as a separate test case in the allure report
+test_name: Say hello
+
+includes:
+  - !include common.yaml
+
+marks:
+  - parametrize:
+      key: name
+      vals:
+        - Jim
+        - Bob
+        - Alice
+
+stages:
+  - type: ref
+    id: login_get_token
+
+  - name: Say hello to {name}
+    request:
+      url: "{service:s}/hello/{name}"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data: "Hello, {name}"

--- a/example/allure/tests/test_ping.tavern.yaml
+++ b/example/allure/tests/test_ping.tavern.yaml
@@ -1,0 +1,27 @@
+---
+test_name: Ping the server
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: Unauthenticated ping
+    request:
+      url: "{service:s}/ping"
+      method: GET
+    response:
+      status_code: 401
+
+  - type: ref
+    id: login_get_token
+
+  - name: Authenticated ping
+    request:
+      url: "{service:s}/ping"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data: pong

--- a/scripts/smoke.bash
+++ b/scripts/smoke.bash
@@ -22,4 +22,4 @@ $TOX_CMD --parallel -c tox.ini        \
   -e py3
 
 $TOX_CMD -c tox-integration.ini -p auto \
-  -e py3-graphql,py3-generic,py3-http,py3-grpc,py3-mqtt
+  -e py3-graphql,py3-generic,py3-http,py3-grpc,py3-mqtt,py3-allure

--- a/tavern/_core/pytest/file.py
+++ b/tavern/_core/pytest/file.py
@@ -332,6 +332,7 @@ def _get_parametrized_items(
             spec_new["test_name"], parent, spec_new, parent.path
         )
         item_new.add_markers(pytest_marks)
+        item_new.parametrize_vars = variables
 
         yield item_new
 

--- a/tavern/_core/pytest/item.py
+++ b/tavern/_core/pytest/item.py
@@ -1,7 +1,8 @@
 import dataclasses
 import logging
 import pathlib
-from collections.abc import Callable, Iterable, MutableMapping
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
+from typing import Any
 
 import pytest
 import yaml
@@ -22,7 +23,7 @@ from tavern._core.loader import error_on_empty_scalar
 from tavern._core.plugins import load_plugins
 from tavern._core.pytest import call_hook
 from tavern._core.pytest.error import ReprdError
-from tavern._core.report import attach_text
+from tavern._core.report import attach_parameters, attach_text
 from tavern._core.run import run_test
 from tavern._core.schema.files import verify_tests
 from tavern._core.stage_lines import start_mark
@@ -79,12 +80,14 @@ class YamlItem(pytest.Item):
         path: filename that this test came from
         spec: The whole dictionary of the test
         global_cfg: configuration for test
+        parametrize_vars: values this test was parametrized with, if any
     """
 
     # See https://github.com/taverntesting/tavern/issues/825
     _patched_yaml = False
 
     global_cfg: TestConfig
+    parametrize_vars: Mapping[str, Any] = {}
 
     def __init__(
         self, *, name: str, parent, spec: MutableMapping, path: pathlib.Path, **kwargs
@@ -237,6 +240,8 @@ class YamlItem(pytest.Item):
         return values
 
     def runtest(self) -> None:
+        attach_parameters(self.parametrize_vars)
+
         self.global_cfg = load_global_cfg(self.config)
 
         load_plugins(self.global_cfg)

--- a/tavern/_core/report.py
+++ b/tavern/_core/report.py
@@ -1,14 +1,17 @@
 import logging
+from collections.abc import Mapping
 from textwrap import dedent
-from typing import Union
+from typing import Any, Union
 
 import yaml
 
 try:
-    from allure import attach, step
+    from allure import attach, dynamic, step
     from allure import attachment_type as at
 
     yaml_type = at.YAML
+
+    _report_parameter = dynamic.parameter
 except ImportError:
     yaml_type = None
 
@@ -20,6 +23,9 @@ except ImportError:
             return step_func
 
         return call
+
+    def _report_parameter(*args, **kwargs) -> None:
+        logger.debug("Not reporting parameter as allure is not installed")
 
 
 from tavern._core.formatted_str import FormattedString
@@ -71,6 +77,17 @@ def attach_yaml(payload, name: str) -> None:
 
 def attach_text(payload, name: str, attachment_type=None) -> None:
     return attach(payload, name=name, attachment_type=attachment_type)
+
+
+def attach_parameters(parameters: Mapping[str, Any]) -> None:
+    """Report the values a test was parametrized with
+
+    Tavern generates a separate item per parametrize combination instead of using
+    pytest's parametrisation, so there is no 'callspec' for allure to read the
+    parameters from - without this, every generated test gets the same history id.
+    """
+    for name, value in parameters.items():
+        _report_parameter(name, value)
 
 
 def wrap_step(allure_name: str, partial):

--- a/tests/unit/test_allure.py
+++ b/tests/unit/test_allure.py
@@ -1,0 +1,44 @@
+import json
+
+pytest_plugins = ["pytester"]
+
+PARAMETRIZED_TEST = """
+---
+test_name: Parametrized test
+
+marks:
+  - parametrize:
+      key: wallet_address
+      vals:
+        - aaaaaaaa
+        - bbbbbbbb
+
+stages:
+  - name: Request to a port nothing is listening on
+    request:
+      url: "http://localhost:1/{wallet_address}"
+      method: GET
+    response:
+      status_code: 200
+"""
+
+
+def test_parametrized_items_have_unique_allure_history_ids(pytester):
+    """Each parametrized test should be a separate test case in the allure report
+
+    See https://github.com/taverntesting/tavern/issues/1078
+    """
+    pytester.makefile(".tavern.yaml", test_param=PARAMETRIZED_TEST)
+    allure_dir = pytester.path / "allure"
+
+    # In a subprocess because running a tavern test patches the yaml parser globally
+    # (see https://github.com/taverntesting/tavern/issues/825)
+    result = pytester.runpytest_subprocess("--alluredir", str(allure_dir))
+    result.assert_outcomes(failed=2)
+
+    reported = [json.loads(f.read_text()) for f in allure_dir.glob("*-result.json")]
+    assert len(reported) == 2
+    assert len({r["historyId"] for r in reported}) == 2
+    assert {
+        (p["name"], p["value"]) for r in reported for p in r["parameters"]
+    } == {("wallet_address", "'aaaaaaaa'"), ("wallet_address", "'bbbbbbbb'")}

--- a/tests/unit/test_allure.py
+++ b/tests/unit/test_allure.py
@@ -39,6 +39,7 @@ def test_parametrized_items_have_unique_allure_history_ids(pytester):
     reported = [json.loads(f.read_text()) for f in allure_dir.glob("*-result.json")]
     assert len(reported) == 2
     assert len({r["historyId"] for r in reported}) == 2
-    assert {
-        (p["name"], p["value"]) for r in reported for p in r["parameters"]
-    } == {("wallet_address", "'aaaaaaaa'"), ("wallet_address", "'bbbbbbbb'")}
+    assert {(p["name"], p["value"]) for r in reported for p in r["parameters"]} == {
+        ("wallet_address", "'aaaaaaaa'"),
+        ("wallet_address", "'bbbbbbbb'"),
+    }

--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3-{generic,mqtt,grpc,http,graphql,noextra}
+envlist = py3-{generic,mqtt,grpc,http,graphql,noextra,allure}
 
 [testenv]
 dependency_groups =
@@ -17,6 +17,7 @@ changedir =
     mqtt: example/mqtt
     http: example/http
     graphql: example/graphql
+    allure: example/allure
     generic: tests/integration
     noextra: tests/integration
 deps =
@@ -38,7 +39,12 @@ commands =
 ;    docker compose build
     docker compose up --build -d
     python -m pytest --collect-only
-    python -m pytest --tavern-global-cfg={toxinidir}/tests/integration/global_cfg.yaml --cov tavern {posargs} --tavern-setup-init-logging
+    !allure: python -m pytest --tavern-global-cfg={toxinidir}/tests/integration/global_cfg.yaml --cov tavern {posargs} --tavern-setup-init-logging
+
+    ; Generate a report to check that eg parametrized tests show up separately in it
+    allure: python -c "import shutil; shutil.rmtree('allure-results', ignore_errors=True)"
+    allure: python -m pytest --alluredir=allure-results {posargs}
+    allure: docker compose run --rm allure generate /allure-results --clean --single-file -o /allure-report
 
     generic: py.test --tavern-global-cfg={toxinidir}/tests/integration/global_cfg.yaml -n 3
     generic: tavern-ci --stdout . --tavern-global-cfg={toxinidir}/tests/integration/global_cfg.yaml


### PR DESCRIPTION
Closes https://github.com/taverntesting/tavern/issues/1078



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Allure integration example with authenticated “hello” and “ping” scenarios.
  * Added support for displaying test parameters in Allure reports.
  * Added single-file HTML report generation for integration tests.

* **Bug Fixes**
  * Parametrised tests now retain distinct parameter values and generate unique Allure history entries.

* **Documentation**
  * Added guidance for running the Allure example and generating reports.

* **Tests**
  * Added automated coverage for Allure parameter reporting and report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->