### PR TITLE
fix: list_any_order strict matching lets one response item satisfy du…

### DIFF
--- a/tavern/_core/dict_util.py
+++ b/tavern/_core/dict_util.py
@@ -484,42 +484,74 @@ def check_keys_match_recursive(
             if not strict_bool:
                 missing = []
 
-                actual_iter = iter(actual_val)
+                if strict_setting == StrictSetting.LIST_ANY_ORDER:
+                    # Each response item can only be used to satisfy one expected
+                    # item - remove it from the pool of remaining candidates once
+                    # matched so duplicate expected values aren't matched against
+                    # the same response item more than once.
+                    remaining = list(actual_val)
 
-                # Iterate over list items to see if any of them match _IN ORDER_
-                for i, e_val in enumerate(expected_val):
-                    while 1:
-                        try:
-                            current_response_val = next(actual_iter)
-                        except StopIteration:
-                            # Still iterating checking for a value, but ran out of response values
-                            logger.debug("Ran out of list response items to check")
-                            missing.append(e_val)
-                            break
-                        else:
+                    for i, e_val in enumerate(expected_val):
+                        for idx, current_response_val in enumerate(remaining):
                             logger.debug(
                                 "Got '%s' from response to check against '%s' from expected",
                                 current_response_val,
                                 e_val,
                             )
 
-                        # Found one - check if it matches
-                        try:
-                            check_keys_match_recursive(
-                                e_val, current_response_val, keys + [i], strict
-                            )
-                        except exceptions.KeyMismatchError:
-                            # Doesn't match what we're looking for
-                            logger.debug(
-                                "%s did not match next response value %s",
-                                e_val,
-                                current_response_val,
-                            )
+                            try:
+                                check_keys_match_recursive(
+                                    e_val, current_response_val, keys + [i], strict
+                                )
+                            except exceptions.KeyMismatchError:
+                                # Doesn't match what we're looking for
+                                logger.debug(
+                                    "%s did not match response value %s",
+                                    e_val,
+                                    current_response_val,
+                                )
+                            else:
+                                logger.debug("'%s' present in response", e_val)
+                                del remaining[idx]
+                                break
                         else:
-                            logger.debug("'%s' present in response", e_val)
-                            if strict_setting == StrictSetting.LIST_ANY_ORDER:
-                                actual_iter = iter(actual_val)
-                            break
+                            logger.debug("Ran out of list response items to check")
+                            missing.append(e_val)
+                else:
+                    actual_iter = iter(actual_val)
+
+                    # Iterate over list items to see if any of them match _IN ORDER_
+                    for i, e_val in enumerate(expected_val):
+                        while 1:
+                            try:
+                                current_response_val = next(actual_iter)
+                            except StopIteration:
+                                # Still iterating checking for a value, but ran out of response values
+                                logger.debug("Ran out of list response items to check")
+                                missing.append(e_val)
+                                break
+                            else:
+                                logger.debug(
+                                    "Got '%s' from response to check against '%s' from expected",
+                                    current_response_val,
+                                    e_val,
+                                )
+
+                            # Found one - check if it matches
+                            try:
+                                check_keys_match_recursive(
+                                    e_val, current_response_val, keys + [i], strict
+                                )
+                            except exceptions.KeyMismatchError:
+                                # Doesn't match what we're looking for
+                                logger.debug(
+                                    "%s did not match next response value %s",
+                                    e_val,
+                                    current_response_val,
+                                )
+                            else:
+                                logger.debug("'%s' present in response", e_val)
+                                break
 
                 if missing:
                     msg = f"List item(s) not present in response: {missing}"

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -30,6 +30,7 @@ from tavern._core.loader import (
 )
 from tavern._core.schema.extensions import validate_extensions
 from tavern._core.schema.files import wrapfile
+from tavern._core.strict_util import StrictOption, StrictSetting
 
 
 class TestValidateFunctions:
@@ -288,6 +289,45 @@ class TestNonStrictListMatching:
 
         with pytest.raises(exceptions.KeyMismatchError):
             check_keys_match_recursive(a, b, [], strict=False)
+
+
+class TestListAnyOrderMatching:
+    """https://github.com/taverntesting/tavern - 'list_any_order' should match a
+    response list against the expected list disregarding order, but each response
+    item should still only be able to satisfy one expected item"""
+
+    def strict(self):
+        return StrictOption("json", StrictSetting.LIST_ANY_ORDER)
+
+    def test_match_any_order(self):
+        """Matches even though the order is different"""
+        a = ["a", "b"]
+        b = ["b", "a"]
+
+        check_keys_match_recursive(a, b, [], strict=self.strict())
+
+    def test_match_duplicates(self):
+        """Duplicated expected items match duplicated response items"""
+        a = ["a", "a"]
+        b = ["a", "a"]
+
+        check_keys_match_recursive(a, b, [], strict=self.strict())
+
+    def test_does_not_match_when_response_has_fewer_duplicates(self):
+        """A single response item can't be reused to satisfy more than one
+        expected item"""
+        a = ["a", "a"]
+        b = ["a"]
+
+        with pytest.raises(exceptions.KeyMismatchError):
+            check_keys_match_recursive(a, b, [], strict=self.strict())
+
+    def test_does_not_match_missing_item(self):
+        a = ["a", "b"]
+        b = ["a"]
+
+        with pytest.raises(exceptions.KeyMismatchError):
+            check_keys_match_recursive(a, b, [], strict=self.strict())
 
 
 @pytest.fixture(name="test_yaml")


### PR DESCRIPTION
# Fix `list_any_order` duplicate matching

## Summary

Fixes `strict: json:list_any_order` allowing the same response item to satisfy multiple expected items.

For example:

```python
expected = ["a", "a"]
actual = ["a"]
```

This incorrectly passed because the actual-items iterator was reset after each match, allowing `"a"` to be reused.

## Fix

Use a pool of remaining response items and remove each item once matched. This ensures each actual item can satisfy only one expected item while still allowing any order.

The order-sensitive matching behavior is unchanged.

## Testing

Added tests covering:

* Reordered items
* Correct duplicate matching
* Fewer duplicates than expected
* Missing items


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unordered list matching so each response item can satisfy only one expected entry.
  * Correctly reports missing expected entries when there are insufficient response items.
  * Preserved existing in-order list matching behaviour.

* **Tests**
  * Added coverage for unordered list matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->