### PR TITLE
feat: better grpc handling

### DIFF
--- a/docs/source/grpc.md
+++ b/docs/source/grpc.md
@@ -125,6 +125,60 @@ stages:
       status: "OK"  # Also the default
 ```
 
+If the status is not `OK` then there is no response message to check, so specifying a `body` as
+well as a non-`OK` `status` is an error.
+
+### Checking errors
+
+The error message which the server returned along with the status - the string passed to
+`set_details`/`abort` on the server - is checked with the `error_message` key. As well as a plain
+string this can be one of the [type sentinels](./core_concepts/types.md) which match a string,
+such as `!re_search`:
+
+```yaml
+stages:
+  - name: Say hello to nobody
+    grpc_request:
+      service: helloworld.v1.Greeter/SayHello
+      body:
+        name: ""
+    grpc_response:
+      status: "INVALID_ARGUMENT"
+      error_message: !re_search "no name"
+```
+
+A server can also attach structured error details to the response. This is not part of gRPC
+itself - as described in the [gRPC error handling
+documentation](https://grpc.io/docs/guides/error/), it is a Google convention for using gRPC with
+protobuf, where the server puts a `google.rpc.Status` containing arbitrary messages into the
+`grpc-status-details-bin` trailing metadata. Tavern only officially supports protobuf, so this is
+how the `details` key is checked.
+
+Each message in the status is converted to a mapping including the `@type` key identifying it,
+and the list of them is matched like any other response body. Fields which the server did not set
+are left out, so only the fields actually returned need to be specified even with strict key
+checking turned on:
+
+```yaml
+stages:
+  - name: Say hello to nobody
+    grpc_request:
+      service: helloworld.v1.Greeter/SayHello
+      body:
+        name: ""
+    grpc_response:
+      status: "INVALID_ARGUMENT"
+      details:
+        - "@type": type.googleapis.com/google.rpc.BadRequest
+          field_violations:
+            - field: name
+              description: "name must not be empty"
+```
+
+The protobuf definition of each message in the details has to have been loaded (see below) for it
+to be checked - the `google.rpc` messages such as `BadRequest` and `ErrorInfo` are available
+already because Tavern depends on them.
+
 ## Loading protobuf definitions
 
 There are 3 different ways Tavern will try to load the appropriate proto definitions:

--- a/example/grpc/tavern_grpc_example/server.py
+++ b/example/grpc/tavern_grpc_example/server.py
@@ -11,23 +11,60 @@ import helloworld_v2_compiled_pb2 as helloworld_pb2_v2
 import helloworld_v2_compiled_pb2_grpc as helloworld_pb2_grpc_v2
 import helloworld_v3_reflected_pb2 as helloworld_pb2_v3
 import helloworld_v3_reflected_pb2_grpc as helloworld_pb2_grpc_v3
+from google.protobuf import any_pb2
+from google.rpc import code_pb2, error_details_pb2, status_pb2
 from grpc_interceptor import ServerInterceptor
 from grpc_interceptor.exceptions import GrpcException
 from grpc_reflection.v1alpha import reflection
+from grpc_status import rpc_status
+
+
+def abort_with_rich_details(context: grpc.ServicerContext) -> None:
+    """Abort the request with a google.rpc.Status
+
+    As well as the 'details' string this attaches the 'rich' error details to the response,
+    which are the arbitrary messages packed into the status.
+    """
+    packed = any_pb2.Any()
+    packed.Pack(
+        error_details_pb2.BadRequest(
+            field_violations=[
+                error_details_pb2.BadRequest.FieldViolation(
+                    field="name", description="name must not be empty"
+                )
+            ]
+        )
+    )
+
+    context.abort_with_status(
+        rpc_status.to_status(
+            status_pb2.Status(
+                code=code_pb2.INVALID_ARGUMENT,
+                message="no name given",
+                details=[packed],
+            )
+        )
+    )
 
 
 class GreeterV1(helloworld_pb2_grpc_v1.GreeterServicer):
     def SayHello(self, request, context):
+        if not request.name:
+            abort_with_rich_details(context)
         return helloworld_pb2_v1.HelloReply(message=f"Hello, {request.name}!")
 
 
 class GreeterV2(helloworld_pb2_grpc_v2.GreeterServicer):
     def SayHello(self, request, context):
+        if not request.name:
+            abort_with_rich_details(context)
         return helloworld_pb2_v2.HelloReply(message=f"Hello, {request.name}!")
 
 
 class GreeterV3(helloworld_pb2_grpc_v3.GreeterServicer):
     def SayHello(self, request, context):
+        if not request.name:
+            abort_with_rich_details(context)
         return helloworld_pb2_v3.HelloReply(message=f"Hello, {request.name}!")
 
 

--- a/example/grpc/tests/test_grpc.tavern.yaml
+++ b/example/grpc/tests/test_grpc.tavern.yaml
@@ -464,3 +464,146 @@ stages:
       status: "ABORTED"
       body:
         message: "Hello, Jim!"
+
+---
+
+test_name: Test checking the error message of an error response
+
+includes:
+  - !include common.yaml
+
+grpc: *grpc_spec
+
+stages:
+  - name: Say hello to nobody
+    grpc_request:
+      service: helloworld.v2.Greeter/SayHello
+      body:
+        name: ""
+    grpc_response:
+      status: "INVALID_ARGUMENT"
+      error_message: "no name given"
+
+  - name: The error message can be matched with a regex as well
+    grpc_request:
+      service: helloworld.v2.Greeter/SayHello
+      body:
+        name: ""
+    grpc_response:
+      status: "INVALID_ARGUMENT"
+      error_message: !re_search "no name"
+
+---
+
+test_name: Test checking the error details of an error response
+
+includes:
+  - !include common.yaml
+
+grpc: *grpc_spec
+
+stages:
+  - name: Say hello to nobody
+    grpc_request:
+      service: helloworld.v2.Greeter/SayHello
+      body:
+        name: ""
+    grpc_response:
+      status: "INVALID_ARGUMENT"
+      details:
+        - "@type": type.googleapis.com/google.rpc.BadRequest
+          field_violations:
+            - field: name
+              description: "name must not be empty"
+
+---
+
+test_name: Test the error message of an error response not matching
+
+includes:
+  - !include common.yaml
+
+grpc: *grpc_spec
+
+_xfail:
+  run: "expected[\"error_message\"] = 'a completely different message'"
+
+stages:
+  - name: Say hello to nobody
+    grpc_request:
+      service: helloworld.v2.Greeter/SayHello
+      body:
+        name: ""
+    grpc_response:
+      status: "INVALID_ARGUMENT"
+      error_message: "a completely different message"
+
+---
+
+test_name: Test the error details of an error response not matching
+
+includes:
+  - !include common.yaml
+
+grpc: *grpc_spec
+
+_xfail:
+  run: "expected[\"details\"][\"0\"][\"field_violations\"][\"0\"][\"field\"] = 'greeting'"
+
+stages:
+  - name: Say hello to nobody
+    grpc_request:
+      service: helloworld.v2.Greeter/SayHello
+      body:
+        name: ""
+    grpc_response:
+      status: "INVALID_ARGUMENT"
+      details:
+        - "@type": type.googleapis.com/google.rpc.BadRequest
+          field_violations:
+            - field: greeting
+              description: "name must not be empty"
+
+---
+
+test_name: Test expecting error details when the response has none
+
+includes:
+  - !include common.yaml
+
+grpc: *grpc_spec
+
+_xfail:
+  run: "expected error details"
+
+stages:
+  - name: Echo text
+    grpc_request:
+      service: helloworld.v2.Greeter/SayHello
+      body:
+        name: "John"
+    grpc_response:
+      status: "OK"
+      details:
+        - "@type": type.googleapis.com/google.rpc.BadRequest
+
+---
+
+test_name: Test the error details cannot be a plain string
+
+includes:
+  - !include common.yaml
+
+grpc: *grpc_spec
+
+_xfail: verify
+
+stages:
+  - name: Say hello to nobody
+    grpc_request:
+      service: helloworld.v2.Greeter/SayHello
+      body:
+        name: ""
+    grpc_response:
+      status: "INVALID_ARGUMENT"
+      details: "no name given"

--- a/example/grpc/tests/test_grpc.tavern.yaml
+++ b/example/grpc/tests/test_grpc.tavern.yaml
@@ -441,3 +441,26 @@ stages:
       status: "GREETINGS"
       body:
         message: "Hello, Jim!"
+
+---
+
+test_name: Test cannot expect a body along with a non-OK status
+
+includes:
+  - !include common.yaml
+
+grpc: *grpc_spec
+
+_xfail:
+  run: "'body' was specified in response, but expected status code was not 'OK'"
+
+stages:
+  - name: Echo text
+    grpc_request:
+      service: helloworld.v1.Greeter/SayHello
+      body:
+        name: "Jim"
+    grpc_response:
+      status: "ABORTED"
+      body:
+        message: "Hello, Jim!"

--- a/tavern/_core/schema/tests.schema.yaml
+++ b/tavern/_core/schema/tests.schema.yaml
@@ -149,6 +149,9 @@ schema;stage:
         status:
           type: any
           func: validate_grpc_status_is_valid_or_list_of_names
+        error_message:
+          type: any
+          required: false
         details:
           type: any
           required: false

--- a/tavern/_plugins/grpc/jsonschema.yaml
+++ b/tavern/_plugins/grpc/jsonschema.yaml
@@ -38,10 +38,23 @@ definitions:
           - type: string
           - type: integer
 
-      details:
-        type: object
+      error_message:
+        description: |
+          Expected error message on the response - the string passed to set_details/abort by the
+          server. As well as a plain string this can be a sentinel matching one, like !re_search.
+        oneOf:
+          - type: string
+          - type: object
 
-      proto_body:
+      details:
+        description: |
+          Expected error details attached to the response - the messages packed into the
+          google.rpc.Status, each one including the '@type' identifying it.
+        oneOf:
+          - type: array
+          - type: object
+
+      body:
         type: object
 
       timeout:

--- a/tavern/_plugins/grpc/response.py
+++ b/tavern/_plugins/grpc/response.py
@@ -6,9 +6,15 @@ import grpc
 import proto.message
 from google.protobuf import json_format
 
+# Imported for the side effect of registering the standard google.rpc error details (BadRequest,
+# ErrorInfo, etc.) in the descriptor pool, so they can be unpacked from a response
+from google.rpc import error_details_pb2  # noqa: F401
+from grpc_status import rpc_status
+
 from tavern._core import exceptions
-from tavern._core.dict_util import check_expected_keys
+from tavern._core.dict_util import check_expected_keys, check_keys_match_recursive
 from tavern._core.exceptions import TestFailError
+from tavern._core.loader import ANYTHING
 from tavern._core.pytest.config import TestConfig
 from tavern._core.schema.extensions import to_grpc_status
 from tavern._plugins.grpc.client import GRPCClient
@@ -38,6 +44,7 @@ class _GRPCExpected(TypedDict):
     """What the 'expected' block for a grpc response should contain"""
 
     status: GRPCCode
+    error_message: Any
     details: Any
     body: Mapping
 
@@ -50,7 +57,9 @@ class GRPCResponse(BaseResponse):
         expected: _GRPCExpected | Mapping,
         test_block_config: TestConfig,
     ) -> None:
-        check_expected_keys({"body", "status", "details", "save"}, expected)
+        check_expected_keys(
+            {"body", "status", "error_message", "details", "save"}, expected
+        )
         super().__init__(
             name,
             expected,
@@ -90,6 +99,88 @@ class GRPCResponse(BaseResponse):
         block_strictness = test_strictness.option_for(blockname)
         self.recurse_check_key_match(expected_block, block, blockname, block_strictness)
 
+    def _verify_error_message(self, grpc_response: grpc.Call | grpc.Future) -> None:
+        """Check the expected error message against the 'details' string of the response
+
+        This is the string passed to set_details/abort on the server - not to be confused with
+        the 'details' of the response block, which are the messages in the google.rpc.Status.
+        """
+        self._check_match(
+            self.expected["error_message"],
+            grpc_response.details() or "",
+            "error_message",
+        )
+
+    def _verify_details(self, grpc_response: grpc.Call | grpc.Future) -> None:
+        """Check the expected error details against the ones attached to the response"""
+        expected_details = self.expected["details"]
+
+        actual_details = self._get_rich_details(grpc_response)
+
+        if actual_details is None and expected_details is not ANYTHING:
+            self._adderr(
+                "expected error details '%s' in the response, but there were none",
+                expected_details,
+            )
+            return
+
+        self._check_match(expected_details, actual_details, "details")
+
+    def _check_match(self, expected: Any, actual: Any, blockname: str) -> None:
+        """Compare part of the response, adding an error if it does not match
+
+        Going through the normal matching rather than just comparing the values means type
+        sentinels like !re_search or !anything can be used.
+        """
+        try:
+            check_keys_match_recursive(
+                expected,
+                actual,
+                [blockname],
+                self.test_block_config.strict.option_for("json"),
+            )
+        except exceptions.KeyMismatchError as e:
+            self._adderr(e.args[0], e=e)
+
+    def _get_rich_details(
+        self, grpc_response: grpc.Call | grpc.Future
+    ) -> list[Any] | None:
+        """Get the rich error details attached to the response, as json
+
+        These are the messages (google.rpc.BadRequest, google.rpc.ErrorInfo, etc.) packed into
+        the google.rpc.Status which the server put into the 'grpc-status-details-bin' trailing
+        metadata, as described in https://grpc.io/docs/guides/error/. Each one is converted to a
+        dict including the '@type' key identifying it.
+        """
+        try:
+            status = rpc_status.from_call(grpc_response)  # type:ignore[arg-type]
+        except ValueError as e:
+            self._adderr(
+                "response contained rich error details, but they did not match the status of the response itself",
+                e=e,
+            )
+            return None
+
+        if status is None:
+            logger.debug("no rich error details on response")
+            return None
+
+        try:
+            # Unlike the response body, fields which were not set are left out - the details are
+            # a bag of arbitrary messages, so making the user spell out every unset field of
+            # every one of them would be unusable with strict key checking turned on
+            as_dict = json_format.MessageToDict(
+                status,
+                preserving_proto_field_name=True,
+            )
+        except (json_format.Error, TypeError) as e:
+            # Happens if one of the packed messages is not in the descriptor pool, ie the proto
+            # defining it was never loaded
+            self._adderr("unable to parse rich error details from response: %s", e, e=e)
+            return None
+
+        return as_dict.get("details", [])
+
     def verify(self, response: "WrappedFuture") -> Mapping:
         grpc_response = response.response
 
@@ -109,14 +200,11 @@ class GRPCResponse(BaseResponse):
                 grpc_response.code().name,
             )
 
+        if "error_message" in self.expected:
+            self._verify_error_message(grpc_response)
+
         if "details" in self.expected:
-            verify_details = self.expected["details"]
-            if verify_details != grpc_response.details():
-                self._adderr(
-                    "expected details '%s', but the actual response '%s'",
-                    verify_details,
-                    grpc_response.details(),
-                )
+            self._verify_details(grpc_response)
 
         saved = self._handle_grpc_response(grpc_response, response, verify_status) or {}
 

--- a/tavern/_plugins/grpc/response.py
+++ b/tavern/_plugins/grpc/response.py
@@ -134,13 +134,6 @@ class GRPCResponse(BaseResponse):
         response: "WrappedFuture",
         verify_status: list[str],
     ) -> Optional[dict[str, Any]]:
-        if grpc_response.code().name != "OK":
-            # TODO: Should allow checking grpc RPC error details etc.
-            logger.info(
-                f"skipping body checking due to {grpc_response.code()} response"
-            )
-            return None
-
         if "body" in self.expected and verify_status != ["OK"]:
             self._adderr(
                 "'body' was specified in response, but expected status code was not 'OK'"
@@ -148,7 +141,25 @@ class GRPCResponse(BaseResponse):
             return None
 
         _, output_type = self._client.get_method_types(response.service_name)
-        result: proto.message.Message = grpc_response.result()
+
+        try:
+            result: proto.message.Message = grpc_response.result()
+        except grpc.RpcError as e:
+            # A non-OK response has no message attached to it, so there is
+            # nothing to check an expected body against
+            # TODO: Should allow checking grpc RPC error details etc.
+            if "body" in self.expected:
+                self._adderr(
+                    "expected a response body, but the request failed with status '%s' (%s)",
+                    grpc_response.code().name,
+                    grpc_response.details(),
+                    e=e,
+                )
+            else:
+                logger.info(
+                    f"no response body to check due to {grpc_response.code()} response"
+                )
+            return None
 
         if not isinstance(result, output_type):
             # Note: This is probably unexpected in some cases

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,4 +41,16 @@ def set_plugins():
             )
         )
 
+    try:
+        import tavern._plugins.grpc.tavernhook as grpc_plugin
+    except ImportError:
+        pass
+    else:
+        plugins.append(
+            extension(
+                "grpc",
+                grpc_plugin,
+            )
+        )
+
     tavern._core.plugins.load_plugins.plugins = plugins

--- a/tests/unit/tavern_grpc/test_grpc.py
+++ b/tests/unit/tavern_grpc/test_grpc.py
@@ -20,7 +20,7 @@ from tavern._core import exceptions
 from tavern._core.loader import _RegexSearchSentinel
 from tavern._core.pytest.config import TestConfig
 from tavern._plugins.grpc.client import GRPCClient
-from tavern._plugins.grpc.request import GRPCRequest
+from tavern._plugins.grpc.request import GRPCRequest, WrappedFuture
 from tavern._plugins.grpc.response import GRPCCode, GRPCResponse, _to_grpc_name
 
 sys.path.append(os.path.dirname(__file__))
@@ -114,88 +114,88 @@ class GRPCRequestSpec:
 
 
 @dataclasses.dataclass
-class GRPCTestSpec:
+class GRPCTestSpec(GRPCRequestSpec):
     """A request which is sent to the server, and the response checked against 'expected'"""
-
-    test_name: str
-    method: str
-    req: Any
 
     resp: Any | None = None
     # Expected error message on the response - a string, or a sentinel matching one
     error_message: Any | None = None
     # Expected error details attached to the response
     details: Any | None = None
-    expected_exception: type[Exception] | None = None
+    code: GRPCCode = grpc.StatusCode.OK.value[0]
+
+    def expected_response(self) -> dict[str, Any]:
+        """The 'grpc_response' block to check the response against"""
+        expected: dict[str, Any] = {"status": self.code}
+        if self.resp:
+            expected["body"] = json_format.MessageToDict(
+                self.resp,
+                always_print_fields_with_no_presence=True,
+                preserving_proto_field_name=True,
+            )
+        if self.error_message is not None:
+            expected["error_message"] = self.error_message
+        if self.details is not None:
+            expected["details"] = self.details
+
+        return expected
+
+
+@dataclasses.dataclass
+class GRPCFailureSpec(GRPCTestSpec):
+    """A request which is sent to the server, but where the expected response is wrong"""
+
+    expected_exception: type[Exception] = exceptions.TestFailError
     # Substring which should be in the exception raised, to check the test failed for
     # the reason it was supposed to
     expected_exception_message: str | None = None
-    code: GRPCCode = grpc.StatusCode.OK.value[0]
-    service: str = "tavern.tests.v1.DummyService"
 
-    def service_method(self):
-        return f"{self.service}/{self.method}"
 
-    def request(self) -> Mapping:
-        return json_format.MessageToDict(
-            self.req,
-            always_print_fields_with_no_presence=True,
-            preserving_proto_field_name=True,
-        )
+def _run(
+    grpc_client: GRPCClient, includes: TestConfig, spec: GRPCRequestSpec
+) -> WrappedFuture:
+    """Send the request from the spec to the server"""
+    request = GRPCRequest(
+        grpc_client,
+        {"service": spec.service_method(), "body": spec.request()},
+        includes,
+    )
 
-    def body(self) -> Mapping:
-        return json_format.MessageToDict(
-            self.resp,
-            always_print_fields_with_no_presence=True,
-            preserving_proto_field_name=True,
-        )
+    return request.run()
 
 
 def test_grpc_bad_request(
     grpc_client: GRPCClient, includes: TestConfig, request_spec: GRPCRequestSpec
 ):
     """A request which doesn't match the service definition never reaches the server"""
-    request = GRPCRequest(
-        grpc_client,
-        {"service": request_spec.service_method(), "body": request_spec.request()},
-        includes,
-    )
-
     with pytest.raises(request_spec.expected_exception):
-        request.run()
+        _run(grpc_client, includes, request_spec)
 
 
 def test_grpc(grpc_client: GRPCClient, includes: TestConfig, test_spec: GRPCTestSpec):
-    """The response from the server is checked against the expected response block"""
-    request = GRPCRequest(
-        grpc_client,
-        {"service": test_spec.service_method(), "body": test_spec.request()},
-        includes,
-    )
+    """The status, error message and details of the response are as expected"""
+    resp = GRPCResponse(grpc_client, "test", test_spec.expected_response(), includes)
 
-    expected: dict[str, Any] = {"status": test_spec.code}
-    if test_spec.resp:
-        expected["body"] = test_spec.body()
-    if test_spec.error_message is not None:
-        expected["error_message"] = test_spec.error_message
-    if test_spec.details is not None:
-        expected["details"] = test_spec.details
+    future = _run(grpc_client, includes, test_spec)
 
-    resp = GRPCResponse(grpc_client, "test", expected, includes)
+    assert future.response.code().name == _to_grpc_name(test_spec.code)
+    resp.verify(future)
 
-    future = request.run()
 
-    if not test_spec.expected_exception:
-        assert future.response.code().name == _to_grpc_name(test_spec.code)
-        resp.verify(future)
-        return
+def test_grpc_bad_response(
+    grpc_client: GRPCClient, includes: TestConfig, failure_spec: GRPCFailureSpec
+):
+    """The request runs, but the response does not match what the test expects"""
+    resp = GRPCResponse(grpc_client, "test", failure_spec.expected_response(), includes)
+
+    future = _run(grpc_client, includes, failure_spec)
 
     match = (
-        re.escape(test_spec.expected_exception_message)
-        if test_spec.expected_exception_message
+        re.escape(failure_spec.expected_exception_message)
+        if failure_spec.expected_exception_message
         else None
     )
-    with pytest.raises(test_spec.expected_exception, match=match):
+    with pytest.raises(failure_spec.expected_exception, match=match):
         resp.verify(future)
 
 
@@ -232,22 +232,6 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 code=0,
             ),
             GRPCTestSpec(
-                test_name="empty with wrong status code",
-                method="Empty",
-                req=Empty(),
-                resp=Empty(),
-                code="ABORTED",
-                expected_exception=exceptions.TestFailError,
-            ),
-            GRPCTestSpec(
-                test_name="empty with the wrong response type",
-                method="Empty",
-                req=Empty(),
-                resp=test_services_pb2.DummyResponse(),
-                code=0,
-                expected_exception=exceptions.TestFailError,
-            ),
-            GRPCTestSpec(
                 test_name="Simple service",
                 method="SimpleTest",
                 req=test_services_pb2.DummyRequest(request_id=2),
@@ -274,14 +258,6 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 error_message=_RegexSearchSentinel(re.compile("too big")),
             ),
             GRPCTestSpec(
-                test_name="Simple service with error and the wrong error message",
-                method="SimpleTest",
-                req=test_services_pb2.DummyRequest(request_id=10000),
-                code="FAILED_PRECONDITION",
-                error_message="number too small!",
-                expected_exception=exceptions.TestFailError,
-            ),
-            GRPCTestSpec(
                 test_name="Simple service with error and matching details",
                 method="SimpleTest",
                 req=test_services_pb2.DummyRequest(request_id=10000),
@@ -295,7 +271,37 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                     }
                 ],
             ),
-            GRPCTestSpec(
+        ]
+
+        metafunc.parametrize("test_spec", tests, ids=[t.test_name for t in tests])
+
+    if "failure_spec" in metafunc.fixturenames:
+        failures = [
+            GRPCFailureSpec(
+                test_name="empty with wrong status code",
+                method="Empty",
+                req=Empty(),
+                resp=Empty(),
+                code="ABORTED",
+                expected_exception_message="expected status ['ABORTED'], but the actual response 'OK'",
+            ),
+            GRPCFailureSpec(
+                test_name="empty with the wrong response type",
+                method="Empty",
+                req=Empty(),
+                resp=test_services_pb2.DummyResponse(),
+                code=0,
+                expected_exception_message='Message type "google.protobuf.Empty" has no field named "response_id"',
+            ),
+            GRPCFailureSpec(
+                test_name="Simple service with error and the wrong error message",
+                method="SimpleTest",
+                req=test_services_pb2.DummyRequest(request_id=10000),
+                code="FAILED_PRECONDITION",
+                error_message="number too small!",
+                expected_exception_message="expected[\"error_message\"] = 'number too small!'",
+            ),
+            GRPCFailureSpec(
                 test_name="Simple service with error and the wrong details",
                 method="SimpleTest",
                 req=test_services_pb2.DummyRequest(request_id=10000),
@@ -308,10 +314,9 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                         ],
                     }
                 ],
-                expected_exception=exceptions.TestFailError,
-                error_message="number too small!",
+                expected_exception_message='expected["details"]["0"]["field_violations"]["0"]["description"] = \'number too small!\'',
             ),
-            GRPCTestSpec(
+            GRPCFailureSpec(
                 test_name="Simple service expecting details but there are none",
                 method="SimpleTest",
                 req=test_services_pb2.DummyRequest(request_id=2),
@@ -319,38 +324,39 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 details=[
                     {"@type": "type.googleapis.com/google.rpc.BadRequest"},
                 ],
-                expected_exception=exceptions.TestFailError,
                 expected_exception_message="expected error details",
             ),
-            GRPCTestSpec(
+            GRPCFailureSpec(
                 test_name="Simple service with error code but also a response",
                 method="SimpleTest",
                 req=test_services_pb2.DummyRequest(request_id=10000),
                 resp=test_services_pb2.DummyResponse(response_id=3),
                 code="FAILED_PRECONDITION",
-                expected_exception=exceptions.TestFailError,
+                expected_exception_message="'body' was specified in response, but expected status code was not 'OK'",
             ),
-            GRPCTestSpec(
+            GRPCFailureSpec(
                 test_name="Simple service expecting a body but the request errors",
                 method="SimpleTest",
                 req=test_services_pb2.DummyRequest(request_id=10000),
                 resp=test_services_pb2.DummyResponse(response_id=3),
-                expected_exception=exceptions.TestFailError,
+                expected_exception_message="expected a response body, but the request failed with status 'FAILED_PRECONDITION' (number too big!)",
             ),
-            GRPCTestSpec(
+            GRPCFailureSpec(
                 test_name="Simple service with wrong request type",
                 method="SimpleTest",
                 req=Empty(),
                 resp=test_services_pb2.DummyResponse(response_id=3),
-                expected_exception=exceptions.TestFailError,
+                expected_exception_message="expected[\"response_id\"] = '3'",
             ),
-            GRPCTestSpec(
+            GRPCFailureSpec(
                 test_name="Simple service with wrong response type",
                 method="SimpleTest",
                 req=test_services_pb2.DummyRequest(request_id=2),
                 resp=Empty(),
-                expected_exception=exceptions.TestFailError,
+                expected_exception_message="Extra keys in response: {'response_id'}",
             ),
         ]
 
-        metafunc.parametrize("test_spec", tests, ids=[t.test_name for t in tests])
+        metafunc.parametrize(
+            "failure_spec", failures, ids=[t.test_name for t in failures]
+        )

--- a/tests/unit/tavern_grpc/test_grpc.py
+++ b/tests/unit/tavern_grpc/test_grpc.py
@@ -92,7 +92,31 @@ def grpc_client(service: int) -> GRPCClient:
 
 
 @dataclasses.dataclass
+class GRPCRequestSpec:
+    """A request which is invalid, so it fails before anything is sent to the server"""
+
+    test_name: str
+    method: str
+    req: Any
+
+    expected_exception: type[Exception] = exceptions.GRPCRequestException
+    service: str = "tavern.tests.v1.DummyService"
+
+    def service_method(self) -> str:
+        return f"{self.service}/{self.method}"
+
+    def request(self) -> Mapping:
+        return json_format.MessageToDict(
+            self.req,
+            always_print_fields_with_no_presence=True,
+            preserving_proto_field_name=True,
+        )
+
+
+@dataclasses.dataclass
 class GRPCTestSpec:
+    """A request which is sent to the server, and the response checked against 'expected'"""
+
     test_name: str
     method: str
     req: Any
@@ -103,23 +127,11 @@ class GRPCTestSpec:
     # Expected error details attached to the response
     details: Any | None = None
     expected_exception: type[Exception] | None = None
-    # Substring which should be in the error raised, to check the test failed for the
-    # reason it was supposed to
-    expected_error: str | None = None
+    # Substring which should be in the exception raised, to check the test failed for
+    # the reason it was supposed to
+    expected_exception_message: str | None = None
     code: GRPCCode = grpc.StatusCode.OK.value[0]
-    # The status the server is actually expected to return - only needs setting
-    # for tests which deliberately expect the 'wrong' status in 'code'
-    actual_code: GRPCCode | None = None
     service: str = "tavern.tests.v1.DummyService"
-
-    def actual_status_name(self) -> str:
-        """Name of the grpc status the server should respond with"""
-        name = _to_grpc_name(
-            self.code if self.actual_code is None else self.actual_code
-        )
-        if not isinstance(name, str):
-            raise ValueError("can only check a single expected status code")
-        return name
 
     def service_method(self):
         return f"{self.service}/{self.method}"
@@ -139,7 +151,22 @@ class GRPCTestSpec:
         )
 
 
+def test_grpc_bad_request(
+    grpc_client: GRPCClient, includes: TestConfig, request_spec: GRPCRequestSpec
+):
+    """A request which doesn't match the service definition never reaches the server"""
+    request = GRPCRequest(
+        grpc_client,
+        {"service": request_spec.service_method(), "body": request_spec.request()},
+        includes,
+    )
+
+    with pytest.raises(request_spec.expected_exception):
+        request.run()
+
+
 def test_grpc(grpc_client: GRPCClient, includes: TestConfig, test_spec: GRPCTestSpec):
+    """The response from the server is checked against the expected response block"""
     request = GRPCRequest(
         grpc_client,
         {"service": test_spec.service_method(), "body": test_spec.request()},
@@ -156,38 +183,46 @@ def test_grpc(grpc_client: GRPCClient, includes: TestConfig, test_spec: GRPCTest
 
     resp = GRPCResponse(grpc_client, "test", expected, includes)
 
+    future = request.run()
+
     if not test_spec.expected_exception:
-        future = request.run()
-        assert future.response.code().name == test_spec.actual_status_name()
+        assert future.response.code().name == _to_grpc_name(test_spec.code)
         resp.verify(future)
         return
 
-    # Some specs are expected to fail before the request is even sent, in which
-    # case there is no status code to check
-    try:
-        future = request.run()
-    except test_spec.expected_exception:
-        return
-
-    assert future.response.code().name == test_spec.actual_status_name()
-
-    match = re.escape(test_spec.expected_error) if test_spec.expected_error else None
+    match = (
+        re.escape(test_spec.expected_exception_message)
+        if test_spec.expected_exception_message
+        else None
+    )
     with pytest.raises(test_spec.expected_exception, match=match):
         resp.verify(future)
 
 
 def pytest_generate_tests(metafunc: MarkGenerator):
+    if "request_spec" in metafunc.fixturenames:
+        requests = [
+            GRPCRequestSpec(
+                test_name="nonexistent method",
+                method="Wek",
+                req=Empty(),
+                expected_exception=exceptions.GRPCServiceException,
+            ),
+            GRPCRequestSpec(
+                test_name="the wrong request type",
+                method="Empty",
+                req=test_services_pb2.DummyRequest(),
+            ),
+        ]
+
+        metafunc.parametrize(
+            "request_spec", requests, ids=[t.test_name for t in requests]
+        )
+
     if "test_spec" in metafunc.fixturenames:
         tests = [
             GRPCTestSpec(
                 test_name="basic empty", method="Empty", req=Empty(), resp=Empty()
-            ),
-            GRPCTestSpec(
-                test_name="nonexistent method",
-                method="Wek",
-                req=Empty(),
-                resp=Empty(),
-                expected_exception=exceptions.GRPCServiceException,
             ),
             GRPCTestSpec(
                 test_name="empty with numeric status code",
@@ -202,16 +237,7 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 req=Empty(),
                 resp=Empty(),
                 code="ABORTED",
-                actual_code="OK",
                 expected_exception=exceptions.TestFailError,
-            ),
-            GRPCTestSpec(
-                test_name="empty with the wrong request type",
-                method="Empty",
-                req=test_services_pb2.DummyRequest(),
-                resp=Empty(),
-                code=0,
-                expected_exception=exceptions.GRPCRequestException,
             ),
             GRPCTestSpec(
                 test_name="empty with the wrong response type",
@@ -254,7 +280,6 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 code="FAILED_PRECONDITION",
                 error_message="number too small!",
                 expected_exception=exceptions.TestFailError,
-                expected_error="expected[\"error_message\"] = 'number too small!'",
             ),
             GRPCTestSpec(
                 test_name="Simple service with error and matching details",
@@ -284,7 +309,7 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                     }
                 ],
                 expected_exception=exceptions.TestFailError,
-                expected_error='expected["details"]["0"]["field_violations"]["0"]["description"] = \'number too small!\'',
+                error_message="number too small!",
             ),
             GRPCTestSpec(
                 test_name="Simple service expecting details but there are none",
@@ -295,7 +320,7 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                     {"@type": "type.googleapis.com/google.rpc.BadRequest"},
                 ],
                 expected_exception=exceptions.TestFailError,
-                expected_error="expected error details",
+                expected_exception_message="expected error details",
             ),
             GRPCTestSpec(
                 test_name="Simple service with error code but also a response",
@@ -310,7 +335,6 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 method="SimpleTest",
                 req=test_services_pb2.DummyRequest(request_id=10000),
                 resp=test_services_pb2.DummyResponse(response_id=3),
-                actual_code="FAILED_PRECONDITION",
                 expected_exception=exceptions.TestFailError,
             ),
             GRPCTestSpec(

--- a/tests/unit/tavern_grpc/test_grpc.py
+++ b/tests/unit/tavern_grpc/test_grpc.py
@@ -93,13 +93,12 @@ def grpc_client(service: int) -> GRPCClient:
 
 @dataclasses.dataclass
 class GRPCRequestSpec:
-    """A request which is invalid, so it fails before anything is sent to the server"""
+    """A request to send to the dummy service"""
 
     test_name: str
     method: str
     req: Any
 
-    expected_exception: type[Exception] = exceptions.GRPCRequestException
     service: str = "tavern.tests.v1.DummyService"
 
     def service_method(self) -> str:
@@ -111,6 +110,34 @@ class GRPCRequestSpec:
             always_print_fields_with_no_presence=True,
             preserving_proto_field_name=True,
         )
+
+
+def _run(
+    grpc_client: GRPCClient, includes: TestConfig, spec: GRPCRequestSpec
+) -> WrappedFuture:
+    """Send the request from the spec to the server"""
+    request = GRPCRequest(
+        grpc_client,
+        {"service": spec.service_method(), "body": spec.request()},
+        includes,
+    )
+
+    return request.run()
+
+
+@dataclasses.dataclass
+class GRPCBadRequestSpec(GRPCRequestSpec):
+    """A request which is invalid, so it fails before anything is sent to the server"""
+
+    expected_exception: type[Exception] = exceptions.GRPCRequestException
+
+
+def test_grpc_bad_request(
+    grpc_client: GRPCClient, includes: TestConfig, request_spec: GRPCBadRequestSpec
+):
+    """A request which doesn't match the service definition never reaches the server"""
+    with pytest.raises(request_spec.expected_exception):
+        _run(grpc_client, includes, request_spec)
 
 
 @dataclasses.dataclass
@@ -141,37 +168,6 @@ class GRPCTestSpec(GRPCRequestSpec):
         return expected
 
 
-@dataclasses.dataclass
-class GRPCFailureSpec(GRPCTestSpec):
-    """A request which is sent to the server, but where the expected response is wrong"""
-
-    expected_exception: type[Exception] = exceptions.TestFailError
-    # Substring which should be in the exception raised, to check the test failed for
-    # the reason it was supposed to
-    expected_exception_message: str | None = None
-
-
-def _run(
-    grpc_client: GRPCClient, includes: TestConfig, spec: GRPCRequestSpec
-) -> WrappedFuture:
-    """Send the request from the spec to the server"""
-    request = GRPCRequest(
-        grpc_client,
-        {"service": spec.service_method(), "body": spec.request()},
-        includes,
-    )
-
-    return request.run()
-
-
-def test_grpc_bad_request(
-    grpc_client: GRPCClient, includes: TestConfig, request_spec: GRPCRequestSpec
-):
-    """A request which doesn't match the service definition never reaches the server"""
-    with pytest.raises(request_spec.expected_exception):
-        _run(grpc_client, includes, request_spec)
-
-
 def test_grpc(grpc_client: GRPCClient, includes: TestConfig, test_spec: GRPCTestSpec):
     """The status, error message and details of the response are as expected"""
     resp = GRPCResponse(grpc_client, "test", test_spec.expected_response(), includes)
@@ -182,10 +178,20 @@ def test_grpc(grpc_client: GRPCClient, includes: TestConfig, test_spec: GRPCTest
     resp.verify(future)
 
 
+@dataclasses.dataclass
+class GRPCFailureSpec(GRPCTestSpec):
+    """A request which is sent to the server, but where the expected response is wrong"""
+
+    expected_exception: type[Exception] = exceptions.TestFailError
+    # Substring which should be in the exception raised, to check the test failed for
+    # the reason it was supposed to
+    expected_exception_message: str | None = None
+
+
 def test_grpc_bad_response(
     grpc_client: GRPCClient, includes: TestConfig, failure_spec: GRPCFailureSpec
 ):
-    """The request runs, but the response does not match what the test expects"""
+    """The request runs, but the response does not match the 'expected' response"""
     resp = GRPCResponse(grpc_client, "test", failure_spec.expected_response(), includes)
 
     future = _run(grpc_client, includes, failure_spec)
@@ -202,13 +208,13 @@ def test_grpc_bad_response(
 def pytest_generate_tests(metafunc: MarkGenerator):
     if "request_spec" in metafunc.fixturenames:
         requests = [
-            GRPCRequestSpec(
+            GRPCBadRequestSpec(
                 test_name="nonexistent method",
                 method="Wek",
                 req=Empty(),
                 expected_exception=exceptions.GRPCServiceException,
             ),
-            GRPCRequestSpec(
+            GRPCBadRequestSpec(
                 test_name="the wrong request type",
                 method="Empty",
                 req=test_services_pb2.DummyRequest(),

--- a/tests/unit/tavern_grpc/test_grpc.py
+++ b/tests/unit/tavern_grpc/test_grpc.py
@@ -1,6 +1,7 @@
 import dataclasses
 import os.path
 import random
+import re
 import sys
 from collections.abc import Generator, Mapping
 from concurrent import futures
@@ -8,12 +9,15 @@ from typing import Any
 
 import grpc
 import pytest
-from google.protobuf import json_format
+from google.protobuf import any_pb2, json_format
 from google.protobuf.empty_pb2 import Empty
+from google.rpc import code_pb2, error_details_pb2, status_pb2
 from grpc_reflection.v1alpha import reflection
+from grpc_status import rpc_status
 from pytest import MarkGenerator
 
 from tavern._core import exceptions
+from tavern._core.loader import _RegexSearchSentinel
 from tavern._core.pytest.config import TestConfig
 from tavern._plugins.grpc.client import GRPCClient
 from tavern._plugins.grpc.request import GRPCRequest
@@ -32,7 +36,27 @@ class ServiceImpl(test_services_pb2_grpc.DummyServiceServicer):
         self, request: test_services_pb2.DummyRequest, context: grpc.ServicerContext
     ) -> test_services_pb2.DummyResponse:
         if request.request_id > 1000:
-            context.abort(grpc.StatusCode.FAILED_PRECONDITION, "number too big!")
+            # Aborting with a google.rpc.Status attaches 'rich' error details to the response as
+            # well as the plain details string
+            packed = any_pb2.Any()
+            packed.Pack(
+                error_details_pb2.BadRequest(
+                    field_violations=[
+                        error_details_pb2.BadRequest.FieldViolation(
+                            field="request_id", description="number too big!"
+                        )
+                    ]
+                )
+            )
+            context.abort_with_status(
+                rpc_status.to_status(
+                    status_pb2.Status(
+                        code=code_pb2.FAILED_PRECONDITION,
+                        message="number too big!",
+                        details=[packed],
+                    )
+                )
+            )
         return test_services_pb2.DummyResponse(response_id=request.request_id + 1)
 
 
@@ -74,7 +98,14 @@ class GRPCTestSpec:
     req: Any
 
     resp: Any | None = None
+    # Expected error message on the response - a string, or a sentinel matching one
+    error_message: Any | None = None
+    # Expected error details attached to the response
+    details: Any | None = None
     expected_exception: type[Exception] | None = None
+    # Substring which should be in the error raised, to check the test failed for the
+    # reason it was supposed to
+    expected_error: str | None = None
     code: GRPCCode = grpc.StatusCode.OK.value[0]
     # The status the server is actually expected to return - only needs setting
     # for tests which deliberately expect the 'wrong' status in 'code'
@@ -115,9 +146,13 @@ def test_grpc(grpc_client: GRPCClient, includes: TestConfig, test_spec: GRPCTest
         includes,
     )
 
-    expected = {"status": test_spec.code}
+    expected: dict[str, Any] = {"status": test_spec.code}
     if test_spec.resp:
         expected["body"] = test_spec.body()
+    if test_spec.error_message is not None:
+        expected["error_message"] = test_spec.error_message
+    if test_spec.details is not None:
+        expected["details"] = test_spec.details
 
     resp = GRPCResponse(grpc_client, "test", expected, includes)
 
@@ -136,7 +171,8 @@ def test_grpc(grpc_client: GRPCClient, includes: TestConfig, test_spec: GRPCTest
 
     assert future.response.code().name == test_spec.actual_status_name()
 
-    with pytest.raises(test_spec.expected_exception):
+    match = re.escape(test_spec.expected_error) if test_spec.expected_error else None
+    with pytest.raises(test_spec.expected_exception, match=match):
         resp.verify(future)
 
 
@@ -196,6 +232,70 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 method="SimpleTest",
                 req=test_services_pb2.DummyRequest(request_id=10000),
                 code="FAILED_PRECONDITION",
+            ),
+            GRPCTestSpec(
+                test_name="Simple service with error and matching error message",
+                method="SimpleTest",
+                req=test_services_pb2.DummyRequest(request_id=10000),
+                code="FAILED_PRECONDITION",
+                error_message="number too big!",
+            ),
+            GRPCTestSpec(
+                test_name="Simple service with error message matching a regex",
+                method="SimpleTest",
+                req=test_services_pb2.DummyRequest(request_id=10000),
+                code="FAILED_PRECONDITION",
+                error_message=_RegexSearchSentinel(re.compile("too big")),
+            ),
+            GRPCTestSpec(
+                test_name="Simple service with error and the wrong error message",
+                method="SimpleTest",
+                req=test_services_pb2.DummyRequest(request_id=10000),
+                code="FAILED_PRECONDITION",
+                error_message="number too small!",
+                expected_exception=exceptions.TestFailError,
+                expected_error="expected[\"error_message\"] = 'number too small!'",
+            ),
+            GRPCTestSpec(
+                test_name="Simple service with error and matching details",
+                method="SimpleTest",
+                req=test_services_pb2.DummyRequest(request_id=10000),
+                code="FAILED_PRECONDITION",
+                details=[
+                    {
+                        "@type": "type.googleapis.com/google.rpc.BadRequest",
+                        "field_violations": [
+                            {"field": "request_id", "description": "number too big!"}
+                        ],
+                    }
+                ],
+            ),
+            GRPCTestSpec(
+                test_name="Simple service with error and the wrong details",
+                method="SimpleTest",
+                req=test_services_pb2.DummyRequest(request_id=10000),
+                code="FAILED_PRECONDITION",
+                details=[
+                    {
+                        "@type": "type.googleapis.com/google.rpc.BadRequest",
+                        "field_violations": [
+                            {"field": "request_id", "description": "number too small!"}
+                        ],
+                    }
+                ],
+                expected_exception=exceptions.TestFailError,
+                expected_error='expected["details"]["0"]["field_violations"]["0"]["description"] = \'number too small!\'',
+            ),
+            GRPCTestSpec(
+                test_name="Simple service expecting details but there are none",
+                method="SimpleTest",
+                req=test_services_pb2.DummyRequest(request_id=2),
+                resp=test_services_pb2.DummyResponse(response_id=3),
+                details=[
+                    {"@type": "type.googleapis.com/google.rpc.BadRequest"},
+                ],
+                expected_exception=exceptions.TestFailError,
+                expected_error="expected error details",
             ),
             GRPCTestSpec(
                 test_name="Simple service with error code but also a response",

--- a/tests/unit/tavern_grpc/test_grpc.py
+++ b/tests/unit/tavern_grpc/test_grpc.py
@@ -2,7 +2,7 @@ import dataclasses
 import os.path
 import random
 import sys
-from collections.abc import Mapping
+from collections.abc import Generator, Mapping
 from concurrent import futures
 from typing import Any
 
@@ -13,10 +13,11 @@ from google.protobuf.empty_pb2 import Empty
 from grpc_reflection.v1alpha import reflection
 from pytest import MarkGenerator
 
+from tavern._core import exceptions
 from tavern._core.pytest.config import TestConfig
 from tavern._plugins.grpc.client import GRPCClient
 from tavern._plugins.grpc.request import GRPCRequest
-from tavern._plugins.grpc.response import GRPCCode, GRPCResponse
+from tavern._plugins.grpc.response import GRPCCode, GRPCResponse, _to_grpc_name
 
 sys.path.append(os.path.dirname(__file__))
 
@@ -36,7 +37,7 @@ class ServiceImpl(test_services_pb2_grpc.DummyServiceServicer):
 
 
 @pytest.fixture(scope="session")
-def service() -> int:
+def service() -> Generator[int, Any, None]:
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=5))
     service_impl = ServiceImpl()
     test_services_pb2_grpc.add_DummyServiceServicer_to_server(service_impl, server)
@@ -73,9 +74,21 @@ class GRPCTestSpec:
     req: Any
 
     resp: Any | None = None
-    xfail: bool = False
+    expected_exception: type[Exception] | None = None
     code: GRPCCode = grpc.StatusCode.OK.value[0]
+    # The status the server is actually expected to return - only needs setting
+    # for tests which deliberately expect the 'wrong' status in 'code'
+    actual_code: GRPCCode | None = None
     service: str = "tavern.tests.v1.DummyService"
+
+    def actual_status_name(self) -> str:
+        """Name of the grpc status the server should respond with"""
+        name = _to_grpc_name(
+            self.code if self.actual_code is None else self.actual_code
+        )
+        if not isinstance(name, str):
+            raise ValueError("can only check a single expected status code")
+        return name
 
     def service_method(self):
         return f"{self.service}/{self.method}"
@@ -108,12 +121,23 @@ def test_grpc(grpc_client: GRPCClient, includes: TestConfig, test_spec: GRPCTest
 
     resp = GRPCResponse(grpc_client, "test", expected, includes)
 
-    if test_spec.xfail:
-        pytest.xfail()
+    if not test_spec.expected_exception:
+        future = request.run()
+        assert future.response.code().name == test_spec.actual_status_name()
+        resp.verify(future)
+        return
 
-    future = request.run()
+    # Some specs are expected to fail before the request is even sent, in which
+    # case there is no status code to check
+    try:
+        future = request.run()
+    except test_spec.expected_exception:
+        return
 
-    resp.verify(future)
+    assert future.response.code().name == test_spec.actual_status_name()
+
+    with pytest.raises(test_spec.expected_exception):
+        resp.verify(future)
 
 
 def pytest_generate_tests(metafunc: MarkGenerator):
@@ -127,7 +151,7 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 method="Wek",
                 req=Empty(),
                 resp=Empty(),
-                xfail=True,
+                expected_exception=exceptions.GRPCServiceException,
             ),
             GRPCTestSpec(
                 test_name="empty with numeric status code",
@@ -142,7 +166,8 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 req=Empty(),
                 resp=Empty(),
                 code="ABORTED",
-                xfail=True,
+                actual_code="OK",
+                expected_exception=exceptions.TestFailError,
             ),
             GRPCTestSpec(
                 test_name="empty with the wrong request type",
@@ -150,7 +175,7 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 req=test_services_pb2.DummyRequest(),
                 resp=Empty(),
                 code=0,
-                xfail=True,
+                expected_exception=exceptions.GRPCRequestException,
             ),
             GRPCTestSpec(
                 test_name="empty with the wrong response type",
@@ -158,7 +183,7 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 req=Empty(),
                 resp=test_services_pb2.DummyResponse(),
                 code=0,
-                xfail=True,
+                expected_exception=exceptions.TestFailError,
             ),
             GRPCTestSpec(
                 test_name="Simple service",
@@ -178,22 +203,30 @@ def pytest_generate_tests(metafunc: MarkGenerator):
                 req=test_services_pb2.DummyRequest(request_id=10000),
                 resp=test_services_pb2.DummyResponse(response_id=3),
                 code="FAILED_PRECONDITION",
-                xfail=True,
+                expected_exception=exceptions.TestFailError,
+            ),
+            GRPCTestSpec(
+                test_name="Simple service expecting a body but the request errors",
+                method="SimpleTest",
+                req=test_services_pb2.DummyRequest(request_id=10000),
+                resp=test_services_pb2.DummyResponse(response_id=3),
+                actual_code="FAILED_PRECONDITION",
+                expected_exception=exceptions.TestFailError,
             ),
             GRPCTestSpec(
                 test_name="Simple service with wrong request type",
                 method="SimpleTest",
                 req=Empty(),
                 resp=test_services_pb2.DummyResponse(response_id=3),
-                xfail=True,
+                expected_exception=exceptions.TestFailError,
             ),
             GRPCTestSpec(
                 test_name="Simple service with wrong response type",
                 method="SimpleTest",
                 req=test_services_pb2.DummyRequest(request_id=2),
                 resp=Empty(),
-                xfail=True,
+                expected_exception=exceptions.TestFailError,
             ),
         ]
 
-        metafunc.parametrize("test_spec", tests, ids=[g.test_name for g in tests])
+        metafunc.parametrize("test_spec", tests, ids=[t.test_name for t in tests])

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -1,7 +1,7 @@
 import contextlib
 import os
 import tempfile
-from textwrap import dedent
+from textwrap import dedent, indent
 
 import pytest
 import yaml
@@ -131,6 +131,80 @@ class TestVerify:
         test_dict["stages"][0]["request"]["verify"] = incorrect_value
         with pytest.raises(BadSchemaError):
             verify_tests(test_dict)
+
+
+class TestGRPCErrors:
+    """The error message of a grpc response is a string, but the details are the messages from
+    the google.rpc.Status attached to it"""
+
+    @staticmethod
+    def verify_with_response_keys(keys: str):
+        """Verify a grpc test with the given yaml block in the grpc_response"""
+        text = dedent(
+            """
+            ---
+            test_name: Test grpc errors
+
+            grpc:
+              connect:
+                host: localhost
+                port: 50051
+              proto:
+                module: helloworld_pb2_grpc
+
+            stages:
+              - name: Say hello
+                grpc_request:
+                  service: helloworld.v1.Greeter/SayHello
+                  body:
+                    name: John
+                grpc_response:
+                  status: "INVALID_ARGUMENT"
+            """
+        ) + indent(dedent(keys), " " * 6)
+
+        # The file has to still exist while the test is verified, because the source lines are
+        # read to give some context if it fails
+        with TestBadSchemaAtCollect.wrapfile_nondict(text) as filename:
+            verify_tests(load_single_document_yaml(filename))
+
+    @pytest.mark.parametrize(
+        "keys",
+        (
+            'error_message: "no name given"',
+            "error_message: !re_search 'no name'",
+            "error_message: !anystr",
+            "error_message: !anything",
+            "details: !anything",
+            dedent(
+                """
+                details:
+                  - "@type": type.googleapis.com/google.rpc.BadRequest
+                    field_violations:
+                      - field: name
+                        description: "name must not be empty"
+                """
+            ),
+        ),
+        ids=("string", "regex", "anystr", "anything", "any_details", "details"),
+    )
+    def test_valid(self, keys):
+        TestGRPCErrors.verify_with_response_keys(keys)
+
+    @pytest.mark.parametrize(
+        "keys",
+        (
+            "error_message: 1",
+            "error_message: True",
+            # The details are the messages in the status, not the error message
+            'details: "no name given"',
+            "details: 1",
+        ),
+        ids=str,
+    )
+    def test_invalid(self, keys):
+        with pytest.raises(BadSchemaError):
+            TestGRPCErrors.verify_with_response_keys(keys)
 
 
 class TestBadSchemaAtCollect:


### PR DESCRIPTION
change grpc to use 'error_message' for the actual server error message, and 'details' for the rpc details returned in the trailer.

Technically a breaking change(?)